### PR TITLE
implementing unique category value limit

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -36,7 +36,8 @@
     "subcluster": "Sub-Cluster",
     "nodes": "Nodes",
     "attributes": "Attributes",
-    "missing": "Missing"
+    "missing": "Missing",
+    "other": "Other"
   },
   "network_tab": {
     "color": "Color",
@@ -66,7 +67,8 @@
     "fix_all_objects_in_place": "Fix all objects in place",
     "allow_all_objects_to_float": "Allow all objects to float",
     "collapse_cluster": "Collapse cluster",
-    "reset_layout": "Reset layout"
+    "reset_layout": "Reset layout",
+    "category_limit": "Category Limit"
   },
   "statistics": {
     "network_statistics": "Network Statistics",

--- a/locales/es.json
+++ b/locales/es.json
@@ -36,7 +36,8 @@
     "subcluster": "Sub_Agrupamiento",
     "nodes": "Nodos",
     "attributes": "Atributos",
-    "missing": "Faltantes"
+    "missing": "Faltantes",
+    "other": "Otra"
   },
   "network_tab": {
     "color": "Color",

--- a/src/clusternetwork.js
+++ b/src/clusternetwork.js
@@ -6455,11 +6455,6 @@ var hivtrace_cluster_network_graph = function (
           }
         );
 
-        // For categories that have too many values, condense them to 10
-
-        console.log(valid_cats);
-        console.log(graph_data[_networkGraphAttrbuteID]);
-
         var valid_shapes = _.filter(valid_cats, function (d) {
           return (
             (d.discrete && d.dimension <= 7) ||

--- a/src/clusternetwork.js
+++ b/src/clusternetwork.js
@@ -548,8 +548,13 @@ var hivtrace_cluster_network_graph = function (
     options && options["cdc-executive-mode"] ? true : false;
 
   self.json = json;
+  self.collapsedCategories = helpers.collapseLargeCategories(
+    json.Nodes,
+    new_schema
+  );
   self.uniqs = helpers.get_unique_count(json.Nodes, new_schema);
   self.uniqValues = helpers.getUniqueValues(json.Nodes, new_schema);
+
   self.schema = json[_networkGraphAttrbuteID];
   // set initial color schemes
   self.networkColorScheme = _networkPresetColorSchemes;
@@ -6449,6 +6454,11 @@ var hivtrace_cluster_network_graph = function (
             );
           }
         );
+
+        // For categories that have too many values, condense them to 10
+
+        console.log(valid_cats);
+        console.log(graph_data[_networkGraphAttrbuteID]);
 
         var valid_shapes = _.filter(valid_cats, function (d) {
           return (

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,6 @@
 var download = require("downloadjs");
 
-const _other = __("general")["other"];
+const _OTHER = __("general")["other"];
 const CATEGORY_UNIQUE_VALUE_LIMIT = 15;
 
 function b64toBlob(b64, onsuccess, onerror) {
@@ -360,8 +360,6 @@ function getUniqueValues(nodes, schema) {
     });
   });
 
-  console.log(new_obj);
-
   // Get uniques across all keys
   return _.mapObject(new_obj, (val) => _.uniq(val));
 }
@@ -398,7 +396,7 @@ function collapseLargeCategories(nodes, schema) {
       // Now take the entries in others and map to "Other"
       _.each(nodes, (n) => {
         if (_.contains(others, n["patient_attributes"][sk])) {
-          n["patient_attributes"][sk] = _other;
+          n["patient_attributes"][sk] = _OTHER;
         }
       });
     }


### PR DESCRIPTION
Implements a limit on number of unique values. The limit can be set within the code and is currently set to 15. The code will sort unique values by order of frequency, select the 15th element's number of appearances, then collapse all unique values with that number of appearances or lower into "Other" (or Otra in Spanish). 