### PR TITLE
Dockerfile -> RHEL 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Docker image for an HIV-TRACE Viz development environment
-FROM oraclelinux:8
+# Docker image for an HIV-TRACE Viz development environment (Red Hat Universal Base Image 8.10)
+FROM redhat/ubi8:8.10
 
 # Set up environment and install dependencies
 RUN yum -y update && \


### PR DESCRIPTION
This PR migrates the `Dockerfile` from Oracle Linux to RHEL 8 (technically Red Hat UBI 8, which is their public Docker base image that is equivalent to their enterprise RHEL 8 image)