### PR TITLE
add clusterOI update on load, fix executive mode option parsing

### DIFF
--- a/src/clusternetwork.js
+++ b/src/clusternetwork.js
@@ -83,8 +83,7 @@ var hivtrace_cluster_network_graph = function (
   self._is_CDC_executive_mode = network.check_network_option(
     options,
     "cdc-executive-mode",
-    false,
-    true
+    false
   );
 
   self.uniqValues = helpers.getUniqueValues(

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -69,10 +69,10 @@ class HIVTxNetwork {
         d3.select(this).attr(
           "transform",
           "translate(" +
-            (d.label_x + d.rendered_size * 1.25) +
-            "," +
-            (d.label_y + d.rendered_size * 0.5) +
-            ")"
+          (d.label_x + d.rendered_size * 1.25) +
+          "," +
+          (d.label_y + d.rendered_size * 0.5) +
+          ")"
         );
       })
       .on("dragstart", () => {
@@ -1156,9 +1156,9 @@ class HIVTxNetwork {
               h.size !== history_entry.size ||
               h.national_priority !== history_entry.national_priority ||
               h.cluster_dx_recent12_mo !==
-                history_entry.cluster_dx_recent12_mo ||
+              history_entry.cluster_dx_recent12_mo ||
               h.cluster_dx_recent36_mo !==
-                history_entry.cluster_dx_recent36_mo ||
+              history_entry.cluster_dx_recent36_mo ||
               h.new_nodes !== history_entry.new_nodes
           );
 
@@ -1446,8 +1446,8 @@ class HIVTxNetwork {
           this.defined_priority_groups.push(...this.auto_create_priority_sets);
         }
         const autocreated = this.defined_priority_groups.filter(
-            (pg) => pg.autocreated
-          ).length,
+          (pg) => pg.autocreated
+        ).length,
           autoexpanded = this.defined_priority_groups.filter(
             (pg) => pg.autoexpanded
           ).length,
@@ -1490,15 +1490,16 @@ class HIVTxNetwork {
         }
 
         this.priority_groups_validate(this.defined_priority_groups);
-        _.each(this.auto_create_priority_sets, (pg) =>
-          this.priority_groups_update_node_sets(pg.name, "insert")
-        );
-        const groups_that_expanded = this.defined_priority_groups.filter(
-          (pg) => pg.expanded
-        );
-        _.each(groups_that_expanded, (pg) =>
-          this.priority_groups_update_node_sets(pg.name, "update")
-        );
+        // Update the DB with the new ClusterOI
+        const auto_create_priority_sets_names = this.auto_create_priority_sets.map(pg => pg.name);
+        _.each(this.defined_priority_groups, (pg) => {
+          if (pg.name in auto_create_priority_sets_names) {
+            this.priority_groups_update_node_sets(pg.name, "insert")
+          } else {
+            // update all ClusterOI (not only just expanded ones, since we need to update ClusterOI history)
+            this.priority_groups_update_node_sets(pg.name, "update")
+          }
+        });
 
         clustersOfInterest.draw_priority_set_table(this);
         if (
@@ -1967,7 +1968,7 @@ class HIVTxNetwork {
           ) {
             var attr_desc =
               network.json[kGlobals.network.GraphAttrbuteID][
-                network.colorizer["category_id"]
+              network.colorizer["category_id"]
               ];
             attr = {};
             attr[network.colorizer["category_id"]] = attr_desc["label"];

--- a/src/network.js
+++ b/src/network.js
@@ -122,7 +122,7 @@ function check_network_option(options, key, if_absent, if_present) {
 
   if (options) {
     if (key in options) {
-      return _.isUndefined(if_present) ? options[key] : if_present;
+      return if_present === undefined ? options[key] : if_present;
     }
   }
   return if_absent;


### PR DESCRIPTION
- Because of the new history field, all priority sets should be updated on load (so that a history entry gets recorded when they are opened by a user). 
- CDC Executive mode parsing wasn't working, so that was fixed as well. 