### PR TITLE
Add DeepWiki Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hivtrace-viz
+# hivtrace-viz  [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/veg/hivtrace-viz)
 
 This repository contains the visualization code for HIV-TRACE.
 


### PR DESCRIPTION
DeepWiki provides up-to-date documentation you can talk to, for every repo in the world. Add this badge to your repository to help users find documentation.