### PR TITLE
feat and fix: support for MJ ClusterOI

### DIFF
--- a/src/clusternetwork.js
+++ b/src/clusternetwork.js
@@ -8698,8 +8698,8 @@ var hivtrace_cluster_network_graph = function (
     if (options["priority-sets-url"]) {
       const is_writeable = options["is-writeable"];
       //  in the MJC case, self.defined_priority_groups (and any other related variables / functions) will be modifying the MJClusterOI, 
-      // while self.own_defined_priority_groups will be the user's own jurisdiction's priority groups (which is loaded in the MJCloadOwnPrioritySets callback)
-      self.MJCloadOwnPrioritySets(options, () => self.load_priority_sets(options["priority-sets-url"], is_writeable));
+      // while self.overlap_defined_priority_groups will be the user's own jurisdiction's priority groups (which is loaded in the callback)
+      self.loadOverlapPrioritySets(options, () => self.load_priority_sets(options["priority-sets-url"], is_writeable));
     }
 
     if (self.showing_diff) {

--- a/src/clusternetwork.js
+++ b/src/clusternetwork.js
@@ -2359,7 +2359,7 @@ var hivtrace_cluster_network_graph = function (
                 use_mjc_overlap_list ? " overlap with MJ clusterOI" : " overlap with other clusterOI")
             );
 
-          const ps = use_mjc_overlap_list ? self.overlap_defined_priority_groups.find((pg) => pg.name === priority_list) : self.priority_groups_find_by_name(priority_list);
+          const ps = self.priority_groups_find_by_name(priority_list);
           if (!ps) return;
           if (!use_mjc_overlap_list && !self.priority_node_overlap) return;
           if (use_mjc_overlap_list && !self.priority_node_overlap_mjc) return;
@@ -2391,7 +2391,7 @@ var hivtrace_cluster_network_graph = function (
               if (eid.includes("REDACTED")) {
                 return;
               }
-              const overlap = use_mjc_overlap_list && !self.isMJCNetwork ? self.priority_node_overlap_mjc[eid] : self.priority_node_overlap[eid];
+              const overlap = (use_mjc_overlap_list && !self.isMJCNetwork) ? self.priority_node_overlap_mjc[eid] : self.priority_node_overlap[eid];
               let other_sets = "None";
               if (overlap && overlap.size > 1) {
                 other_sets = _.sortBy(
@@ -8717,7 +8717,11 @@ var hivtrace_cluster_network_graph = function (
       const is_writeable = options["is-writeable"];
       //  in the MJC case, self.defined_priority_groups (and any other related variables / functions) will be modifying the MJClusterOI, 
       // while self.overlap_defined_priority_groups will be the user's own jurisdiction's priority groups (which is loaded in the callback)
-      self.loadOverlapPrioritySets(options, () => self.load_priority_sets(options["priority-sets-url"], is_writeable));
+      self.loadOverlapPrioritySets(options["overlap-priority-sets-url"], () => self.load_priority_sets(options["priority-sets-url"], is_writeable));
+    }
+
+    if (options["priority-set-add-from-mjc-url"]) {
+      self.priority_set_add_from_mjc_url = options["priority-set-add-from-mjc-url"];
     }
 
     if (options["mjc-archive-url"]) {

--- a/src/clusternetwork.js
+++ b/src/clusternetwork.js
@@ -8698,8 +8698,7 @@ var hivtrace_cluster_network_graph = function (
       const is_writeable = options["is-writeable"];
       //  in the MJC case, self.defined_priority_groups (and any other related variables / functions) will be modifying the MJClusterOI, 
       // while self.own_defined_priority_groups will be the user's own jurisdiction's priority groups (which is loaded in the MJCloadOwnPrioritySets callback)
-      self.load_priority_sets(options["priority-sets-url"], is_writeable);
-      self.MJCloadOwnPrioritySets(options);
+      self.MJCloadOwnPrioritySets(options, () => self.load_priority_sets(options["priority-sets-url"], is_writeable));
     }
 
     if (self.showing_diff) {

--- a/src/clusternetwork.js
+++ b/src/clusternetwork.js
@@ -168,12 +168,20 @@ var hivtrace_cluster_network_graph = function (
       options,
       "priority-table"
     );
+    self.priority_set_archive_table = network.check_network_option(
+      options,
+      "priority-table-archive"
+    );
     self.priority_set_table_write = network.check_network_option(
       options,
       "priority-table-writeback"
     );
-    if (self.priority_set_table)
+    if (self.priority_set_table) {
       self.priority_set_table = d3.select(self.priority_set_table);
+    }
+    if (self.priority_set_archive_table) {
+      self.priority_set_archive_table = d3.select(self.priority_set_archive_table);
+    }
   } else {
     self.priority_set_table = null;
     self.priority_set_table_write = null;
@@ -2337,6 +2345,7 @@ var hivtrace_cluster_network_graph = function (
         (event) => {
           var link_clicked = $(event.relatedTarget);
           var priority_list = link_clicked.data("priority_set");
+          var use_mjc_overlap_list = link_clicked.data("use_mjc_overlap_list");
 
           var modal = d3.select(
             self.get_ui_element_selector_by_role("overlap_list", true)
@@ -2344,13 +2353,16 @@ var hivtrace_cluster_network_graph = function (
           modal
             .selectAll(".modal-title")
             .text(
-              "View how nodes in cluster of interest " +
+              "View how nodes in " + (self.isMJCNetwork ? "MJ " : "") + "clusterOI " +
               priority_list +
-              (self.isMJCNetwork ? " overlap with your jurisdiction's clusterOI" : " overlap with other clusterOI")
+              (self.isMJCNetwork ? " overlap with your jurisdiction's clusterOI" : 
+                use_mjc_overlap_list ? " overlap with MJ clusterOI" : " overlap with other clusterOI")
             );
 
-          const ps = self.priority_groups_find_by_name(priority_list);
-          if (!(ps && self.priority_node_overlap)) return;
+          const ps = use_mjc_overlap_list ? self.overlap_defined_priority_groups.find((pg) => pg.name === priority_list) : self.priority_groups_find_by_name(priority_list);
+          if (!ps) return;
+          if (!use_mjc_overlap_list && !self.priority_node_overlap) return;
+          if (use_mjc_overlap_list && !self.priority_node_overlap_mjc) return;
 
           var headers = [
             [
@@ -2373,10 +2385,13 @@ var hivtrace_cluster_network_graph = function (
           ];
 
           _.each(
-            self.aggregate_indvidual_level_records(ps.node_objects),
+            self.aggregate_indvidual_level_records(use_mjc_overlap_list ? ps.nodes : ps.node_objects),
             (n) => {
               const eid = self.entity_id(n);
-              const overlap = self.priority_node_overlap[eid];
+              if (eid.includes("REDACTED")) {
+                return;
+              }
+              const overlap = use_mjc_overlap_list && !self.isMJCNetwork ? self.priority_node_overlap_mjc[eid] : self.priority_node_overlap[eid];
               let other_sets = "None";
               if (overlap && overlap.size > 1) {
                 other_sets = _.sortBy(
@@ -4015,6 +4030,9 @@ var hivtrace_cluster_network_graph = function (
     );
     if (self.priority_set_table) {
       self.update_volatile_elements(self.priority_set_table);
+    }
+    if (self.priority_set_archive_table) {
+      self.update_volatile_elements(self.priority_set_archive_table);
     }
   };
 
@@ -8700,6 +8718,10 @@ var hivtrace_cluster_network_graph = function (
       //  in the MJC case, self.defined_priority_groups (and any other related variables / functions) will be modifying the MJClusterOI, 
       // while self.overlap_defined_priority_groups will be the user's own jurisdiction's priority groups (which is loaded in the callback)
       self.loadOverlapPrioritySets(options, () => self.load_priority_sets(options["priority-sets-url"], is_writeable));
+    }
+
+    if (options["mjc-archive-url"]) {
+      self.mjc_archive_url = options["mjc-archive-url"];
     }
 
     if (self.showing_diff) {

--- a/src/clusternetwork.js
+++ b/src/clusternetwork.js
@@ -6615,7 +6615,7 @@ var hivtrace_cluster_network_graph = function (
       }*/
     }
 
-    if (self.isMJCNetwork) {
+    if (self.isMJCNetwork && !self.fullMJCNetwork) {
       return;
     }
 

--- a/src/clusternetwork.js
+++ b/src/clusternetwork.js
@@ -99,6 +99,7 @@ var hivtrace_cluster_network_graph = function (
   self.process_multiple_sequences();
 
   self.isMJCNetwork = options && options["is-mjc-network"] ? true : false;
+  self.fullMJCNetwork = options && options["full-mjc-network"] ? true : false;
   self.MJCVariables = self.isMJCNetwork ? (options["mjc-variables"] || {}) : {};
 
   self._is_CDC_ = options && options["no_cdc"] ? false : true;

--- a/src/clusternetwork.js
+++ b/src/clusternetwork.js
@@ -439,14 +439,28 @@ var hivtrace_cluster_network_graph = function (
   };
 
   if (self.isMJCNetwork) {
+    // not actually displayed in node list view
+    self._networkPredefinedAttributeTransforms["mjc_date_identified"] = self.define_attribute_mjc_date_identified(
+      "Date Identified in MJ ClusterOI (Contains All ClusterOI Dates)"
+    );
+    self._networkPredefinedAttributeTransforms["selected_mjc_date_identified"] = self.define_attribute_sel_mjc_date_identified(
+      "Date Identified in MJ ClusterOI"
+    );
+    // not actually displayed in node list view
+    self._networkPredefinedAttributeTransforms["mjc_date_identified_12mo"] = self.define_attribute_mjc_date_identified_12mo(
+      "Identified in Last 12 Mo (Contains All ClusterOI Dates)"
+    );
+    self._networkPredefinedAttributeTransforms["selected_mjc_date_identified_12mo"] = self.define_attribute_sel_mjc_date_identified_12mo(
+      "Identified in Last 12 Mo"
+    );
     self._networkPredefinedAttributeTransforms["hiv_aids_dx_dt_month_year"] = self.define_attribute_dx_month_year(
       "Diagnosis Month/Year"
     );
-    self._networkPredefinedAttributeTransforms["hiv_aids_dx_dt_last_year"] = self.define_attribute_dx_last_year(
+    self._networkPredefinedAttributeTransforms["hiv_aids_dx_dt_12mo"] = self.define_attribute_dx_12mo(
       "DX in Last 12 Mo."
     );
-    self._networkPredefinedAttributeTransforms["mjc_date_added"] = self.define_attribute_mjc_date_added(
-      "Date Added to MJ ClusterOI"
+    self._networkPredefinedAttributeTransforms["hiv_aids_dx_dt_36mo"] = self.define_attribute_dx_36mo(
+      "DX in Last 36 Mo."
     );
   }
 
@@ -2069,23 +2083,34 @@ var hivtrace_cluster_network_graph = function (
         return [];
       }
 
-      // for all nodes in the priority group, update the mjc_date_added to the current viewed priority group
+      // pull from the mjc_date_identified attribute of the nodes directly
       if (priority_group_name) {
-        let priority_group = self.priority_groups_find_by_name(priority_group_name);
-        let nodeToAddedDateMap = {};
-        for (let n of priority_group.nodes) {
-          let value = n.added;
-          if (value !== "REDACTED") {
-            value = timeDateUtil.DateViewFormatExport(this.parse_dates(value));
+        const priority_group = self.priority_groups_find_by_name(priority_group_name);
+        for (const node of priority_group.node_objects) {
+          if (
+            node.patient_attributes && "mjc_date_identified" in node.patient_attributes
+          ) {
+            if (node.patient_attributes.mjc_date_identified === "REDACTED") {
+              node.patient_attributes.selected_mjc_date_identified = "REDACTED";
+            } else if (!(priority_group_name in node.patient_attributes.mjc_date_identified)) {
+              node.patient_attributes.selected_mjc_date_identified = "";
+            } else {
+              node.patient_attributes.selected_mjc_date_identified = timeDateUtil.DateViewFormatExport(
+                this.parse_dates(new Date(
+                  node.patient_attributes.mjc_date_identified[priority_group_name])
+              ));
+            }
           }
-          nodeToAddedDateMap[n.name] = value;
-        }
 
-        if (priority_group) {
-          const cluster_nodes = priority_group.node_objects;
-          _.each(cluster_nodes, (n) => {
-            n.patient_attributes.mjc_date_added = nodeToAddedDateMap[n.id];
-          });
+          if (node.patient_attributes && "mjc_date_identified_12mo" in node.patient_attributes) {
+            if (node.patient_attributes.mjc_date_identified_12mo === "REDACTED") {
+              node.patient_attributes.selected_mjc_date_identified_12mo = "REDACTED";
+            } else if (!(priority_group_name in node.patient_attributes.mjc_date_identified_12mo)) {
+              node.patient_attributes.selected_mjc_date_identified_12mo = "";
+            } else {
+              node.patient_attributes.selected_mjc_date_identified_12mo = node.patient_attributes.mjc_date_identified_12mo[priority_group_name];
+            }
+          }
         }
       }
 
@@ -2093,9 +2118,11 @@ var hivtrace_cluster_network_graph = function (
         'mjc_data_owners',
         'cur_state_cd',
         'rsd_state_cd',
-        'mjc_date_added',
-        'hiv_aids_dx_dt_last_year',
-        'hiv_aids_dx_dt_month_year'
+        'selected_mjc_date_identified',
+        'selected_mjc_date_identified_12mo',
+        'hiv_aids_dx_dt_month_year',
+        'hiv_aids_dx_dt_12mo',
+        'hiv_aids_dx_dt_36mo',
       ];
 
       return MJC_ATTRIBUTES.filter((attr_key =>
@@ -2203,7 +2230,11 @@ var hivtrace_cluster_network_graph = function (
           _.each(column_ids, (column) => {
             patient_list
               .append("dt")
-              .text(column.label || column.raw_attribute_key);
+              .text(column.label || column.raw_attribute_key)
+              .attr("title", column.label || column.raw_attribute_key)
+              .style("width", "50%")
+              .style("text-align", "left")
+              .style("margin-left", "1em");
             patient_list
               .append("dd")
               .text(

--- a/src/clustersOfInterest.js
+++ b/src/clustersOfInterest.js
@@ -1049,6 +1049,7 @@ function open_editor(
     onclosed: function () {
       priority_set_editor = null;
       self.redraw_tables();
+      window.reinitalizeDropdown && window.reinitalizeDropdown();
     },
   });
 }
@@ -1139,9 +1140,7 @@ function _action_drop_down(self, pg) {
                 "priority-edge-length": threshold,
                 title: pg.name + " @" + kGlobals.formats.PercentFormat(threshold),
               });
-              if (window.reinitalizeDropdown) {
-                window.reinitalizeDropdown();
-              }
+              window.reinitalizeDropdown && window.reinitalizeDropdown();
             },
           },
         ];
@@ -1163,9 +1162,7 @@ function _action_drop_down(self, pg) {
                   " (sequence level)",
                 raw_mspp: true,
               });
-              if (window.reinitalizeDropdown) {
-                window.reinitalizeDropdown();
-              }
+              window.reinitalizeDropdown && window.reinitalizeDropdown();
             },
           });
         }
@@ -1249,19 +1246,24 @@ function _action_drop_down(self, pg) {
     dropdown.push({
       label: "Create site ClusterOI from this MJ ClusterOI",
       action: function (button, value) {
-        let ref_set = self.priority_groups_find_by_name(pg.name);
-        if (ref_set) {
-          let copied_node_objects = _.clone(ref_set.node_objects);
-          // TODO: implement. don't actually use the following code, but see the generated response and imitate it
-          // priority_set_inject_node_attibutes(self, copied_node_objects, pg.nodes);
-          // open_editor(
-          //   self,
-          //   copied_node_objects,
-          //   "",
-          //   "Site ClusterOI from " + pg.name,
-          //   ref_set.kind
-          // );
-          // self.redraw_tables();
+        const site_pg_name = "MANUAL_SITE_COPY_" + pg.name;
+        if (confirm("Creating new cluster of interest '" + site_pg_name + "' for this MJ ClusterOI. Proceed?")) {
+          let existing_pg = self.overlap_defined_priority_groups.find((pg) => pg.name === site_pg_name);
+          if (existing_pg) {
+            alert("A cluster of interest with the name '" + site_pg_name + "' already exists in the jurisdiction's ClusterOI. Please rename that clusterOI before creating a new one with the same name.");
+            return;
+          }
+          let ref_set = self.priority_groups_find_by_name(pg.name);
+          if (ref_set) {
+            let copied_node_objects = _.clone(ref_set.node_objects).filter(n => !n.id.startsWith("REDACTED_")).map(n => n.id);
+            self.priority_groups_add_from_mjc(
+              site_pg_name,
+              copied_node_objects,
+              "A copy of " + pg.name + " that contains site sequences only.",
+              "01 state/local molecular cluster analysis",
+              "05. Do not add cases to this cluster of interest. I do not want to monitor growth in this cluster of interest over time."
+            );
+          }
         }
       },
     })
@@ -1271,9 +1273,7 @@ function _action_drop_down(self, pg) {
         let ref_set = self.priority_groups_find_by_name(pg.name);
         if (confirm("Are you sure you want to " + (pg.archived ? "unarchive" : "archive") + " MJ cluster of interest '" + pg.name + "'?")) {
           self.priority_groups_archive_mjc_set(ref_set.name, !pg.archived);
-          if (window.reinitalizeDropdown) {
-            window.reinitalizeDropdown();
-          }
+          window.reinitalizeDropdown && window.reinitalizeDropdown();
         }
       },
     });
@@ -1322,10 +1322,10 @@ function draw_priority_set_table(self, container, priority_groups, archive_table
     self.priority_groups_compute_node_membership();
     if (self.isMJCNetwork) {
       // When computing overlap for MJ ClusterOI views, we need to compare the MJ ClusterOI (self.defined_priority_groups) against the jurisdiction's ClusterOI (self.overlap_defined_priority_groups)
-      self.priority_groups_compute_overlap_mjc(priority_groups, self.overlap_defined_priority_groups, "priority_node_overlap");
+      self.priority_groups_compute_overlap_mjc(priority_groups, self.overlap_defined_priority_groups, "priority_node_overlap", "overlap");
     } else {
       // swapped since for the regular case, defined_priority_groups is the actual pg and overlap_defined_priority_groups is the MJ ClusterOI (if any)
-      self.priority_groups_compute_overlap_mjc(self.overlap_defined_priority_groups, priority_groups, "priority_node_overlap_mjc");
+      self.priority_groups_compute_overlap_mjc(priority_groups, self.overlap_defined_priority_groups, "priority_node_overlap_mjc", "overlap_mjc");
       self.priority_groups_compute_overlap(priority_groups);
     }
     var headers = [
@@ -1431,7 +1431,7 @@ function draw_priority_set_table(self, container, priority_groups, archive_table
           help: self.isMJCNetwork ?
             "How many ClusterOI have overlapping nodes with this MJ ClusterOI, and (if overlapping ClusterOI exist) how many nodes in this MJ ClusterOI overlap with ANY ClusterOI?" :
             "How many MJ ClusterOI have overlapping nodes with this ClusterOI, and (if overlapping MJ ClusterOI exist) how many nodes in this ClusterOI overlap with ANY MJ ClusterOI?",
-            hidden: !self.isMJCNetwork || !self.overlap_defined_priority_groups,
+            hidden: !self.isMJCNetwork && !self.overlap_defined_priority_groups,
         }
         /*,
           {
@@ -1468,7 +1468,6 @@ function draw_priority_set_table(self, container, priority_groups, archive_table
 
     var rows = [];
     _.each(priority_groups, (pg) => {
-      const mjc_pg = self.isMJCNetwork ? pg : self.overlap_defined_priority_groups?.find((p) => p.name === pg.name);
       var this_row = [
         {
           // created by icon
@@ -1708,16 +1707,16 @@ function draw_priority_set_table(self, container, priority_groups, archive_table
         },
       ];
 
-      // MJC Overlap column 
-      // TODO: need to modify text accordingly  
-      if (mjc_pg) {
+      // MJC Overlap column
+      if (self.isMJCNetwork || (!self.isMJCNetwork && self.overlap_defined_priority_groups)) {
+        const overlap = self.isMJCNetwork ? pg.overlap : pg.overlap_mjc;
         this_row.push({
           width: 140,
           value: [
-            mjc_pg.overlap.sets,
-            mjc_pg.overlap.nodes,
-            mjc_pg.overlap.duplicate,
-            mjc_pg.overlap.superset,
+            overlap.sets,
+            overlap.nodes,
+            overlap.duplicate,
+            overlap.superset,
           ],
           format: function (v) {
             if (v) {
@@ -1748,7 +1747,7 @@ function draw_priority_set_table(self, container, priority_groups, archive_table
           },
           html: true,
           actions:
-            mjc_pg.overlap.sets === 0
+            overlap.sets === 0
               ? []
               : [
                 {
@@ -1762,7 +1761,7 @@ function draw_priority_set_table(self, container, priority_groups, archive_table
                           misc.get_ui_element_selector_by_role(
                             "overlap_list"
                           ),
-                        priority_set: mjc_pg.name,
+                        priority_set: pg.name,
                         use_mjc_overlap_list: !self.isMJCNetwork, // for MJ ClusterOI table, show the ClusterOI overlap list; for regular ClusterOI table, show the MJ ClusterOI overlap list
                       },
                     },

--- a/src/clustersOfInterest.js
+++ b/src/clustersOfInterest.js
@@ -1260,8 +1260,8 @@ function _action_drop_down(self, pg) {
               site_pg_name,
               copied_node_objects,
               "A copy of " + pg.name + " that contains site sequences only.",
-              "01 state/local molecular cluster analysis",
-              "05. Do not add cases to this cluster of interest. I do not want to monitor growth in this cluster of interest over time."
+              "02 national molecular cluster analysis",
+              pg.tracking
             );
           }
         }

--- a/src/clustersOfInterest.js
+++ b/src/clustersOfInterest.js
@@ -1467,7 +1467,7 @@ function draw_priority_set_table(self, container, priority_groups, archive_table
 
     var rows = [];
     _.each(priority_groups, (pg) => {
-      const mjc_pg = self.isMJCNetwork ? pg : self.overlap_defined_priority_groups.find((p) => p.name === pg.name);
+      const mjc_pg = self.isMJCNetwork ? self.overlap_defined_priority_groups.find((p) => p.name === pg.name) : pg;
       var this_row = [
         {
           // created by icon

--- a/src/clustersOfInterest.js
+++ b/src/clustersOfInterest.js
@@ -1264,8 +1264,8 @@ function _action_drop_down(self, pg) {
 
 /**
  * Draws a table of priority sets (clusters of interest for regular site views, MJ ClusterOI for MJC views). 
- * For the case of MJ ClusterOI, we assume that self.defined_priority_groups is the MJ ClusterOI and self.own_defined_priority_groups is the jurisdiction's ClusterOI.
-
+ * For the case of MJ ClusterOI, we assume that self.defined_priority_groups is the MJ ClusterOI and self.overlap_defined_priority_groups is the jurisdiction's ClusterOI.
+ * For the case of ClusterOI, we assume that self.defined_priority_groups is regular ClusterOI and self.overlap_defined_priority_groups is MJ ClusterOI (if any).
  * @param {Object} self - The main network visualization object.
  * @param {HTMLElement} container - The HTML element where the table will be displayed (optional).
  * @param {Array} priority_groups - An array of objects representing the priority sets (optional).
@@ -1277,8 +1277,8 @@ function draw_priority_set_table(self, container, priority_groups) {
     priority_groups = priority_groups || self.defined_priority_groups;
     self.priority_groups_compute_node_membership();
     if (self.isMJCNetwork && !self.fullMJCNetwork) {
-      // When computing overlap for MJ ClusterOI views, we need to compare the MJ ClusterOI (self.defined_priority_groups) against the jurisdiction's ClusterOI (self.own_defined_priority_groups)
-      self.priority_groups_compute_overlap_mjc(self.defined_priority_groups, self.own_defined_priority_groups);
+      // When computing overlap for MJ ClusterOI views, we need to compare the MJ ClusterOI (self.defined_priority_groups) against the jurisdiction's ClusterOI (self.overlap_defined_priority_groups)
+      self.priority_groups_compute_overlap_mjc(self.defined_priority_groups, self.overlap_defined_priority_groups);
     } else {
       self.priority_groups_compute_overlap(priority_groups);
     }
@@ -1296,7 +1296,7 @@ function draw_priority_set_table(self, container, priority_groups) {
           value: "Name",
           sort: "value",
           filter: true,
-          width: 325,
+          width: self.isMJCNetwork ? 325 : 200,
           text_wrap: true,
           help: "Cluster of interest name",
           // hidden: self.isMJCNetwork && self.MJCVariables.mjcClusterIdEnabled === false,
@@ -1347,7 +1347,20 @@ function draw_priority_set_table(self, container, priority_groups) {
           // hidden: self.isMJCNetwork && self.MJCVariables.mjcDiagnosesLast12MonthsEnabled === false,
         },
         {
-          value: self.isMJCNetwork ? "My ClusterOI Overlap Count" : "Overlap",
+          value: "Overlap",
+          width: 140,
+          sort: function (c) {
+            c = c.value;
+            if (c) {
+              return c[1];
+            }
+            return 0;
+          },
+          help: "How many other ClusterOI have overlapping nodes with this ClusterOI, and (if overlapping ClusterOI exist) how many nodes in this ClusterOI overlap with ANY other ClusterOI?",
+          hidden: self.isMJCNetwork,
+        },
+        {
+          value: self.isMJCNetwork ? "My ClusterOI Overlap Count" : "MJ ClusterOI Overlap Count",
           width: 140,
           sort: function (c) {
             c = c.value;
@@ -1357,9 +1370,9 @@ function draw_priority_set_table(self, container, priority_groups) {
             return 0;
           },
           help: self.isMJCNetwork ?
-            "How many of my jurisdiction's ClusterOI have overlapping nodes with this MJ ClusterOI?" :
-            "How many other ClusterOI have overlapping nodes with this ClusterOI, and (if overlapping ClusterOI exist) how many nodes in this ClusterOI overlap with ANY other ClusterOI?",
-        },
+            "How many ClusterOI have overlapping nodes with this MJ ClusterOI, and (if overlapping ClusterOI exist) how many nodes in this MJ ClusterOI overlap with ANY ClusterOI?" :
+            "How many MJ ClusterOI have overlapping nodes with this ClusterOI, and (if overlapping MJ ClusterOI exist) how many nodes in this ClusterOI overlap with ANY MJ ClusterOI?",
+        }
         /*,
           {
             value: "Cluster",
@@ -1422,7 +1435,7 @@ function draw_priority_set_table(self, container, priority_groups) {
         {
           // name
           value: self.cleanRedacted(pg.name),
-          width: 325,
+          width: self.isMJCNetwork ? 325 : 200,
           help:
             pg.description +
             (pg.pending ? " (new, pending confirmation)" : "") +
@@ -1532,6 +1545,66 @@ function draw_priority_set_table(self, container, priority_groups) {
           value: (self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcDiagnosesLast12MonthsEnabled === false) ? "REDACTED" : pg.cluster_dx_recent12_mo,
           // hidden: self.isMJCNetwork && self.MJCVariables.mjcDiagnosesLast12MonthsEnabled === false,
         },
+        {
+          width: 140,
+          value: [
+            pg.overlap.sets,
+            pg.overlap.nodes,
+            pg.overlap.duplicate,
+            pg.overlap.superset,
+          ],
+          format: function (v) {
+            if (v) {
+              return (
+                String(v[0]) +
+                (v[1]
+                  ? ' <span title="Number of persons in the overlap" class="label label-default pull-right">' +
+                  v[1] +
+                  " persons</span>"
+                  : "") +
+                (v[2].length
+                  ? ' <span title="clusterOIs which are exact duplicates of this clusterOI: ' +
+                  v[2].join(", ") +
+                  '" class="label label-danger pull-right">' +
+                  v[2].length +
+                  " duplicate clusterOI</span>"
+                  : "") +
+                (v[3].length
+                  ? ' <span title="clusterOIs which contain this clusterOI: ' +
+                  v[3].join(", ") +
+                  '" class="label label-warning pull-right">Fully contained in ' +
+                  v[3].length +
+                  " clusterOI</span>"
+                  : "")
+              );
+            }
+            return "N/A";
+          },
+          html: true,
+          actions:
+            pg.overlap.sets === 0
+              ? []
+              : [
+                {
+                  icon: "fa-eye",
+                  dropdown: [
+                    {
+                      label: "List overlaps",
+                      data: {
+                        toggle: "modal",
+                        target:
+                          misc.get_ui_element_selector_by_role(
+                            "overlap_list"
+                          ),
+                        priority_set: pg.name,
+                      },
+                    },
+                  ],
+                },
+              ],
+          hidden: self.isMJCNetwork,
+        },
+        // MJC Overlap column
         {
           width: 140,
           value: [

--- a/src/clustersOfInterest.js
+++ b/src/clustersOfInterest.js
@@ -1124,7 +1124,7 @@ function handle_inline_confirm(this_button, generator, text, action, disabled) {
 function _action_drop_down(self, pg) {
   let dropdown = [];
 
-  if (!self.isMJCNetwork) {
+  if (!self.isMJCNetwork || self.fullMJCNetwork) {
     const viewClusterOptions = _.flatten([
       _.map([self.subcluster_threshold, 0.015], (threshold) => {
         let items = [
@@ -1276,7 +1276,7 @@ function draw_priority_set_table(self, container, priority_groups) {
   if (container) {
     priority_groups = priority_groups || self.defined_priority_groups;
     self.priority_groups_compute_node_membership();
-    if (self.isMJCNetwork) {
+    if (self.isMJCNetwork && !self.fullMJCNetwork) {
       // When computing overlap for MJ ClusterOI views, we need to compare the MJ ClusterOI (self.defined_priority_groups) against the jurisdiction's ClusterOI (self.own_defined_priority_groups)
       self.priority_groups_compute_overlap_mjc(self.defined_priority_groups, self.own_defined_priority_groups);
     } else {
@@ -1291,7 +1291,6 @@ function draw_priority_set_table(self, container, priority_groups) {
           },
           help: "How was this cluster of interest created",
           width: 50,
-          hidden: self.isMJCNetwork,
         },
         {
           value: "Name",
@@ -1331,7 +1330,7 @@ function draw_priority_set_table(self, container, priority_groups) {
             return 0;
           },
           help: "Number of nodes in the cluster of interest",
-          hidden: self.isMJCNetwork && self.MJCVariables.mjcCurrentSizeEnabled === false,
+          // hidden: self.isMJCNetwork && self.MJCVariables.mjcCurrentSizeEnabled === false,
         },
         {
           value: "Priority",
@@ -1402,8 +1401,12 @@ function draw_priority_set_table(self, container, priority_groups) {
           value: pg.createdBy,
           html: true,
           width: 50,
-          format: (value) =>
-            pg.createdBy === kGlobals.CDCCOICreatedBySystem
+          format: (value) => {
+            if (self.isMJCNetwork) {
+              return "<i class='fa fa-2x fa-globe' title='MJ ClusterOI' data-text-export='MJ ClusterOI'></i>";
+            }
+
+            return pg.createdBy === kGlobals.CDCCOICreatedBySystem
               ? '<i class="fa fa-2x fa-desktop" title="' +
               kGlobals.CDCCOICreatedBySystem +
               '" data-text-export=' +
@@ -1413,8 +1416,8 @@ function draw_priority_set_table(self, container, priority_groups) {
               kGlobals.CDCCOICreatedManually +
               '" data-text-export=' +
               kGlobals.CDCCOICreatedManually +
-              "></i>",
-          hidden: self.isMJCNetwork,
+              "></i>";
+          }
         },
         {
           // name
@@ -1498,6 +1501,9 @@ function draw_priority_set_table(self, container, priority_groups) {
           ],
           width: 100,
           format: function (v) {
+            if (self.isMJCNetwork && !self.fullMJCNetwork) {
+              return "REDACTED";
+            }
             //console.log (pg);
             if (v) {
               return (
@@ -1512,7 +1518,7 @@ function draw_priority_set_table(self, container, priority_groups) {
             return "N/A";
           },
           html: true,
-          hidden: self.isMJCNetwork && self.MJCVariables.mjcCurrentSizeEnabled === false,
+          // hidden: self.isMJCNetwork && self.MJCVariables.mjcCurrentSizeEnabled === false,
         },
         {
           // meets priority definition
@@ -1523,7 +1529,7 @@ function draw_priority_set_table(self, container, priority_groups) {
         {
           width: 100,
           // TODO: actually redact the data on the backend
-          value: (self.isMJCNetwork && self.MJCVariables.mjcDiagnosesLast12MonthsEnabled === false) ? "REDACTED" : pg.cluster_dx_recent12_mo,
+          value: (self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcDiagnosesLast12MonthsEnabled === false) ? "REDACTED" : pg.cluster_dx_recent12_mo,
           // hidden: self.isMJCNetwork && self.MJCVariables.mjcDiagnosesLast12MonthsEnabled === false,
         },
         {

--- a/src/clustersOfInterest.js
+++ b/src/clustersOfInterest.js
@@ -1431,6 +1431,7 @@ function draw_priority_set_table(self, container, priority_groups, archive_table
           help: self.isMJCNetwork ?
             "How many ClusterOI have overlapping nodes with this MJ ClusterOI, and (if overlapping ClusterOI exist) how many nodes in this MJ ClusterOI overlap with ANY ClusterOI?" :
             "How many MJ ClusterOI have overlapping nodes with this ClusterOI, and (if overlapping MJ ClusterOI exist) how many nodes in this ClusterOI overlap with ANY MJ ClusterOI?",
+            hidden: !self.isMJCNetwork || !self.overlap_defined_priority_groups,
         }
         /*,
           {
@@ -1467,7 +1468,7 @@ function draw_priority_set_table(self, container, priority_groups, archive_table
 
     var rows = [];
     _.each(priority_groups, (pg) => {
-      const mjc_pg = self.isMJCNetwork ? self.overlap_defined_priority_groups.find((p) => p.name === pg.name) : pg;
+      const mjc_pg = self.isMJCNetwork ? pg : self.overlap_defined_priority_groups?.find((p) => p.name === pg.name);
       var this_row = [
         {
           // created by icon
@@ -1705,9 +1706,12 @@ function draw_priority_set_table(self, container, priority_groups, archive_table
               ],
           hidden: self.isMJCNetwork,
         },
-        // MJC Overlap column 
-        // TODO: need to modify text accordingly
-        {
+      ];
+
+      // MJC Overlap column 
+      // TODO: need to modify text accordingly  
+      if (mjc_pg) {
+        this_row.push({
           width: 140,
           value: [
             mjc_pg.overlap.sets,
@@ -1765,8 +1769,8 @@ function draw_priority_set_table(self, container, priority_groups, archive_table
                   ],
                 },
               ],
-        },
-      ];
+        });
+      }
 
       if (self._is_CDC_auto_mode) {
         this_row.splice(3, 0, {

--- a/src/clustersOfInterest.js
+++ b/src/clustersOfInterest.js
@@ -1139,6 +1139,9 @@ function _action_drop_down(self, pg) {
                 "priority-edge-length": threshold,
                 title: pg.name + " @" + kGlobals.formats.PercentFormat(threshold),
               });
+              if (window.reinitalizeDropdown) {
+                window.reinitalizeDropdown();
+              }
             },
           },
         ];
@@ -1160,6 +1163,9 @@ function _action_drop_down(self, pg) {
                   " (sequence level)",
                 raw_mspp: true,
               });
+              if (window.reinitalizeDropdown) {
+                window.reinitalizeDropdown();
+              }
             },
           });
         }
@@ -1239,6 +1245,38 @@ function _action_drop_down(self, pg) {
         }
       },
     });
+  } else {
+    dropdown.push({
+      label: "Create site ClusterOI from this MJ ClusterOI",
+      action: function (button, value) {
+        let ref_set = self.priority_groups_find_by_name(pg.name);
+        if (ref_set) {
+          let copied_node_objects = _.clone(ref_set.node_objects);
+          // TODO: implement. don't actually use the following code, but see the generated response and imitate it
+          // priority_set_inject_node_attibutes(self, copied_node_objects, pg.nodes);
+          // open_editor(
+          //   self,
+          //   copied_node_objects,
+          //   "",
+          //   "Site ClusterOI from " + pg.name,
+          //   ref_set.kind
+          // );
+          // self.redraw_tables();
+        }
+      },
+    })
+    dropdown.push({
+      label: pg.archived ? "Unarchive this MJ cluster of interest" : "Archive this MJ cluster of interest",
+      action: function (button, value) {
+        let ref_set = self.priority_groups_find_by_name(pg.name);
+        if (confirm("Are you sure you want to " + (pg.archived ? "unarchive" : "archive") + " MJ cluster of interest '" + pg.name + "'?")) {
+          self.priority_groups_archive_mjc_set(ref_set.name, !pg.archived);
+          if (window.reinitalizeDropdown) {
+            window.reinitalizeDropdown();
+          }
+        }
+      },
+    });
   }
 
   /**dropdown.push({
@@ -1269,17 +1307,25 @@ function _action_drop_down(self, pg) {
  * @param {Object} self - The main network visualization object.
  * @param {HTMLElement} container - The HTML element where the table will be displayed (optional).
  * @param {Array} priority_groups - An array of objects representing the priority sets (optional).
+ * @param {boolean} archive_table - A flag indicating whether the table is for archived clusters of interest (optional).
 */
 
-function draw_priority_set_table(self, container, priority_groups) {
-  container = container || self.priority_set_table;
+function draw_priority_set_table(self, container, priority_groups, archive_table = false) {
+  container = container || (archive_table ? self.priority_set_archive_table : self.priority_set_table);
   if (container) {
     priority_groups = priority_groups || self.defined_priority_groups;
-    self.priority_groups_compute_node_membership();
-    if (self.isMJCNetwork && !self.fullMJCNetwork) {
-      // When computing overlap for MJ ClusterOI views, we need to compare the MJ ClusterOI (self.defined_priority_groups) against the jurisdiction's ClusterOI (self.overlap_defined_priority_groups)
-      self.priority_groups_compute_overlap_mjc(self.defined_priority_groups, self.overlap_defined_priority_groups);
+    if (archive_table) {
+      priority_groups = _.filter(priority_groups, (pg) => pg.archived);
     } else {
+      priority_groups = _.filter(priority_groups, (pg) => !pg.archived);
+    }
+    self.priority_groups_compute_node_membership();
+    if (self.isMJCNetwork) {
+      // When computing overlap for MJ ClusterOI views, we need to compare the MJ ClusterOI (self.defined_priority_groups) against the jurisdiction's ClusterOI (self.overlap_defined_priority_groups)
+      self.priority_groups_compute_overlap_mjc(priority_groups, self.overlap_defined_priority_groups, "priority_node_overlap");
+    } else {
+      // swapped since for the regular case, defined_priority_groups is the actual pg and overlap_defined_priority_groups is the MJ ClusterOI (if any)
+      self.priority_groups_compute_overlap_mjc(self.overlap_defined_priority_groups, priority_groups, "priority_node_overlap_mjc");
       self.priority_groups_compute_overlap(priority_groups);
     }
     var headers = [
@@ -1296,10 +1342,10 @@ function draw_priority_set_table(self, container, priority_groups) {
           value: "Name",
           sort: "value",
           filter: true,
-          width: self.isMJCNetwork ? 325 : 200,
+          width: 200,
           text_wrap: true,
           help: "Cluster of interest name",
-          // hidden: self.isMJCNetwork && self.MJCVariables.mjcClusterIdEnabled === false,
+          // hidden: self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcClusterIdEnabled === false,
         },
         {
           value: "Modified/created",
@@ -1308,14 +1354,14 @@ function draw_priority_set_table(self, container, priority_groups) {
             return c.value[0];
           },
           help: "When was the cluster of interest created/last modified",
-          // hidden: self.isMJCNetwork && self.MJCVariables.mjcModifiedDateEnabled === false,
+          // hidden: self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcModifiedDateEnabled === false,
         },
         {
           value: "Growth",
           sort: "value",
           help: "How growth is handled",
           width: 100,
-          // hidden: self.isMJCNetwork && self.MJCVariables.mjcGrowthCriteriaEnabled === false,
+          // hidden: self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcGrowthCriteriaEnabled === false,
           //text_wrap: true
         },
         {
@@ -1329,22 +1375,35 @@ function draw_priority_set_table(self, container, priority_groups) {
             }
             return 0;
           },
-          help: "Number of nodes in the cluster of interest",
-          // hidden: self.isMJCNetwork && self.MJCVariables.mjcCurrentSizeEnabled === false,
+          help: "Number of nodes in the " + (self.isMJCNetwork ? "MJ " : "") + "clusterOI",
+          // hidden: self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcCurrentSizeEnabled === false,
+        },
+        {
+          value: "My Size",
+          width: 100,
+          sort: function (c) {
+            c = c.value;
+            if (c) {
+              return c[1] + (c[2] ? 1e10 : 0) + (c[3] ? 1e5 : 0);
+            }
+            return 0;
+          },
+          help: "Number of nodes in this MJ clusterOI that are from my jurisdiction",
+          hidden: !self.isMJCNetwork,
         },
         {
           value: "Priority",
           width: 60,
           sort: "value",
           help: "Does the cluster of interest continue to meet priority criteria?",
-          hidden: self.isMJCNetwork && self.MJCVariables.mjcCurrentPriorityEnabled === false,
+          // hidden: self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcCurrentPriorityEnabled === false,
         },
         {
           value: "DXs in last 12 mo.",
           width: 100,
           sort: "value",
           help: "The number of cases in the cluster of interest diagnosed in the past 12 months",
-          // hidden: self.isMJCNetwork && self.MJCVariables.mjcDiagnosesLast12MonthsEnabled === false,
+          // hidden: self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcDiagnosesLast12MonthsEnabled === false,
         },
         {
           value: "Overlap",
@@ -1390,7 +1449,7 @@ function draw_priority_set_table(self, container, priority_groups) {
           return c.value;
         },
         help: "Method of cluster identification",
-        // hidden: self.isMJCNetwork && self.MJCVariables.mjcIdMethodEnabled === false,
+        // hidden: self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcIdMethodEnabled === false,
       });
     }
 
@@ -1408,6 +1467,7 @@ function draw_priority_set_table(self, container, priority_groups) {
 
     var rows = [];
     _.each(priority_groups, (pg) => {
+      const mjc_pg = self.isMJCNetwork ? pg : self.overlap_defined_priority_groups.find((p) => p.name === pg.name);
       var this_row = [
         {
           // created by icon
@@ -1435,7 +1495,7 @@ function draw_priority_set_table(self, container, priority_groups) {
         {
           // name
           value: self.cleanRedacted(pg.name),
-          width: self.isMJCNetwork ? 325 : 200,
+          width: 200,
           help:
             pg.description +
             (pg.pending ? " (new, pending confirmation)" : "") +
@@ -1462,7 +1522,7 @@ function draw_priority_set_table(self, container, priority_groups) {
             "</div>",
           html: true,
           actions: [],
-          // hidden: self.isMJCNetwork && self.MJCVariables.mjcClusterIdEnabled === false,
+          // hidden: self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcClusterIdEnabled === false,
         },
         {
           // modification / creation date
@@ -1476,7 +1536,7 @@ function draw_priority_set_table(self, container, priority_groups) {
             }
             return vs[0];
           },
-          // hidden: self.isMJCNetwork && self.MJCVariables.mjcModifiedDateEnabled === false,
+          // hidden: self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcModifiedDateEnabled === false,
         },
         {
           // tracking mode
@@ -1489,7 +1549,7 @@ function draw_priority_set_table(self, container, priority_groups) {
             }
             return kGlobals.CDCCOIConciseTrackingOptions[value];
           },
-          // hidden: self.isMJCNetwork && self.MJCVariables.mjcGrowthCriteriaEnabled === false,
+          // hidden: self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcGrowthCriteriaEnabled === false,
         },
         {
           // size / new nodes
@@ -1514,7 +1574,7 @@ function draw_priority_set_table(self, container, priority_groups) {
           ],
           width: 100,
           format: function (v) {
-            if (self.isMJCNetwork && !self.fullMJCNetwork) {
+            if (self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcCurrentSizeEnabled === false) {
               return "REDACTED";
             }
             //console.log (pg);
@@ -1531,19 +1591,60 @@ function draw_priority_set_table(self, container, priority_groups) {
             return "N/A";
           },
           html: true,
-          // hidden: self.isMJCNetwork && self.MJCVariables.mjcCurrentSizeEnabled === false,
+          // hidden: self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcCurrentSizeEnabled === false,
+        },
+        {
+          // size / new nodes in my jurisdiction (for MJ ClusterOI, filtered to just nodes from jurisdiction)
+          value: [
+            self.unique_entity_list(pg.node_objects).filter((n) => !n.includes("REDACTED")).length,
+            _.chain(pg.nodes)
+              .filter((n) => !n.name.includes("REDACTED"))
+              .groupBy((n) => self.entity_id_from_string(n.name))
+              .mapObject((v) =>
+                _.uniq(_.map(v, (n) => self.priority_groups_is_new_node(n)))
+              )
+              .filter((v) => v.length == 1 && v[0])
+              .size()
+              .value(),
+          ],
+          width: 100,
+          format: function (v) {
+            if (self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcCurrentSizeEnabled === false) {
+              return "REDACTED";
+            }
+            if (v) {
+              return (
+                v[0] +
+                (v[1]
+                  ? ' <span title="Number of nodes from my jurisdiction added by the system since the last network update" class="label label-default">' +
+                  v[1] +
+                  " new</span>"
+                  : "")
+              );
+            }
+            return "N/A";
+          },
+          html: true,
+          hidden: !self.isMJCNetwork,
         },
         {
           // meets priority definition
           width: 60,
+          format: function (v) {
+            if (self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcCurrentPriorityEnabled === false) {
+              return "<span title='REDACTED'>RED.</span>";
+            }
+            return v ? "Yes" : "No";
+          },
           value: pg.meets_priority_def ? "Yes" : "No",
-          hidden: self.isMJCNetwork && self.MJCVariables.mjcCurrentPriorityEnabled === false,
+          html: true,
+          // hidden: self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcCurrentPriorityEnabled === false,
         },
         {
           width: 100,
           // TODO: actually redact the data on the backend
           value: (self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcDiagnosesLast12MonthsEnabled === false) ? "REDACTED" : pg.cluster_dx_recent12_mo,
-          // hidden: self.isMJCNetwork && self.MJCVariables.mjcDiagnosesLast12MonthsEnabled === false,
+          // hidden: self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcDiagnosesLast12MonthsEnabled === false,
         },
         {
           width: 140,
@@ -1604,14 +1705,15 @@ function draw_priority_set_table(self, container, priority_groups) {
               ],
           hidden: self.isMJCNetwork,
         },
-        // MJC Overlap column
+        // MJC Overlap column 
+        // TODO: need to modify text accordingly
         {
           width: 140,
           value: [
-            pg.overlap.sets,
-            pg.overlap.nodes,
-            pg.overlap.duplicate,
-            pg.overlap.superset,
+            mjc_pg.overlap.sets,
+            mjc_pg.overlap.nodes,
+            mjc_pg.overlap.duplicate,
+            mjc_pg.overlap.superset,
           ],
           format: function (v) {
             if (v) {
@@ -1623,18 +1725,18 @@ function draw_priority_set_table(self, container, priority_groups) {
                   " persons</span>"
                   : "") +
                 (v[2].length
-                  ? ' <span title="clusterOIs which are exact duplicates of this clusterOI: ' +
+                  ? ' <span title="' + (!self.isMJCNetwork ? 'MJ ' : '') + 'clusterOIs which are exact duplicates of this ' + (self.isMJCNetwork ? 'MJ ' : '') + 'clusterOI: ' +
                   v[2].join(", ") +
                   '" class="label label-danger pull-right">' +
                   v[2].length +
-                  " duplicate clusterOI</span>"
+                  " duplicate "+ (!self.isMJCNetwork ? 'MJ ' : '') + "clusterOI</span>"
                   : "") +
                 (v[3].length
-                  ? ' <span title="clusterOIs which contain this clusterOI: ' +
+                  ? ' <span title="' + (!self.isMJCNetwork ? 'MJ ' : '') + 'clusterOIs which contain this ' + (self.isMJCNetwork ? 'MJ ' : '') + 'clusterOI: ' +
                   v[3].join(", ") +
                   '" class="label label-warning pull-right">Fully contained in ' +
                   v[3].length +
-                  " clusterOI</span>"
+                  " "+ (!self.isMJCNetwork ? 'MJ ' : '') + "clusterOI</span>"
                   : "")
               );
             }
@@ -1642,7 +1744,7 @@ function draw_priority_set_table(self, container, priority_groups) {
           },
           html: true,
           actions:
-            pg.overlap.sets === 0
+            mjc_pg.overlap.sets === 0
               ? []
               : [
                 {
@@ -1656,7 +1758,8 @@ function draw_priority_set_table(self, container, priority_groups) {
                           misc.get_ui_element_selector_by_role(
                             "overlap_list"
                           ),
-                        priority_set: pg.name,
+                        priority_set: mjc_pg.name,
+                        use_mjc_overlap_list: !self.isMJCNetwork, // for MJ ClusterOI table, show the ClusterOI overlap list; for regular ClusterOI table, show the MJ ClusterOI overlap list
                       },
                     },
                   ],
@@ -1677,7 +1780,7 @@ function draw_priority_set_table(self, container, priority_groups) {
             return "N/A";
           },
           html: true,
-          // hidden: self.isMJCNetwork && self.MJCVariables.mjcIdMethodEnabled === false,
+          // hidden: self.isMJCNetwork && !self.fullMJCNetwork && self.MJCVariables.mjcIdMethodEnabled === false,
         });
       }
 
@@ -1803,7 +1906,7 @@ function draw_priority_set_table(self, container, priority_groups) {
       rows,
       true,
       has_required_actions +
-      `Showing <span class="badge" data-hivtrace-ui-role="table-count-shown">--</span>/<span class="badge" data-hivtrace-ui-role="table-count-total">--</span> ${self.isMJCNetwork ? 'MJ ' : ''}clusters of interest.
+      `Showing <span class="badge" data-hivtrace-ui-role="table-count-shown">--</span>/<span class="badge" data-hivtrace-ui-role="table-count-total">--</span> ${archive_table ? 'archived ' : ''}${self.isMJCNetwork ? 'MJ ' : ''}clusters of interest.
           ${self.isMJCNetwork ? '' : '<button class = "btn btn-sm btn-warning pull-right" data-hivtrace-ui-role="priority-subclusters-export">Export to JSON</button>'}
           <button class = "btn btn-sm btn-primary pull-right" data-hivtrace-ui-role="priority-subclusters-export-csv" title="Export ClusterOI Node List to CSV">Export to CSV</button>`,
       get_editor()

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -40,14 +40,12 @@ class HIVTxNetwork {
     this.primary_key = _.isFunction(primary_key_function)
       ? primary_key_function
       : (node) => {
-        if (!node.id) {
-          return node.name;
-        }
-        const i = node.id.indexOf("|");
+        const key = node.id || node.name || "";
+        const i = key.indexOf("|");
         if (i >= 0) {
-          return node.id.substr(0, i);
+          return key.substr(0, i);
         }
-        return node.id;
+        return key;
       };
 
     this.tabulate_multiple_sequences();
@@ -902,14 +900,14 @@ class HIVTxNetwork {
     });
   };
 
-  priority_groups_compute_overlap_mjc = (mjc_groups, overlap_groups, output_key) => {
+  priority_groups_compute_overlap_mjc = (defined_groups, overlap_groups, output_key, group_key) => {
     this[output_key] = {};
 
-    if (!mjc_groups || !overlap_groups) {
+    if (!defined_groups || !overlap_groups) {
       return;
     }
 
-    // Build a map of entity lists & sizes for mjc_groups (we will iterate mjc_groups later)
+    // Build a map of entity lists & sizes for defined_groups
     var size_by_pg = {};
 
     // Also keep sizes for overlap_groups for superset/duplicate checks
@@ -930,7 +928,7 @@ class HIVTxNetwork {
     });
 
     // For each mjc group, compute overlap only considering nodes that are present in overlap_groups
-    _.each(mjc_groups, (pg) => {
+    _.each(defined_groups, (pg) => {
       const overlap = {
         sets: new Set(),
         nodes: 0,
@@ -942,7 +940,7 @@ class HIVTxNetwork {
       _.each(pg.nodes, (n) => {
         const entity_id = this.entity_id(n);
 
-        // Only care about nodes in mjc_groups that are present in overlap_groups
+        // Only care about nodes in defined_groups that are present in overlap_groups
         if (entity_id in this[output_key] && this[output_key][entity_id].size > 1) {
           overlap.nodes++;
           this[output_key][entity_id].forEach((overlap_pg_name) => {
@@ -970,7 +968,7 @@ class HIVTxNetwork {
       });
 
       // assign overlap summary to the mjc group
-      pg.overlap = {
+      pg[group_key] = {
         nodes: overlap.nodes,
         // sets = number of distinct overlap_groups that share nodes with this mjc_group
         sets: overlap.sets.size,
@@ -1331,6 +1329,39 @@ class HIVTxNetwork {
       }
     }
   };
+
+  /**
+   * 
+   */
+  priority_groups_add_from_mjc = function (name, node_ids, description, kind, tracking) {
+    fetch(this.priority_set_add_from_mjc_url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: name,
+        node_ids: node_ids,
+        description: description,
+        kind: kind,
+        tracking: tracking,
+      }),
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Network response was not ok");
+        }
+        return response.json();
+      })
+      .then((data) => {
+        alert("ClusterOI '" + name + "' added successfully from MJC.");
+      })
+      .catch((error) => {
+        console.error("Error adding ClusterOI from MJC:", error);
+        alert("Error adding ClusterOI from MJC. Please try again later.");
+      }
+    )
+  }
 
   /**
         A function that updates the "freehand" description
@@ -2637,9 +2668,9 @@ class HIVTxNetwork {
     });
   }
 
-  loadOverlapPrioritySets(options, callback) {
-    if (options["overlap-priority-sets-url"]) {
-      this.overlap_priority_set_url = options["overlap-priority-sets-url"];
+  loadOverlapPrioritySets(overlap_priority_sets_url, callback) {
+    if (overlap_priority_sets_url) {
+      this.overlap_priority_set_url = overlap_priority_sets_url;
       this.fetch_priority_sets(this.overlap_priority_set_url, (results) => {
         this.overlap_defined_priority_groups = results;
         callback();
@@ -2683,7 +2714,6 @@ class HIVTxNetwork {
     .then((data) => {
       clustersOfInterest.draw_priority_set_table(this);
       clustersOfInterest.draw_priority_set_table(this, null, null, true);
-
     });
   }
 

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -2995,7 +2995,7 @@ class HIVTxNetwork {
       };
     }
 
-    define_attribute_mjc_date_added(label) {
+    define_attribute_sel_mjc_date_identified(label) {
       return {
         depends: [],
         label: label,
@@ -3004,6 +3004,62 @@ class HIVTxNetwork {
           // will be dynamically injected into node every time a MJ ClusterOI is viewed
           return kGlobals.missing.label;
         }
+      };
+    }
+
+    define_attribute_mjc_date_identified(label) {
+      return {
+        depends: [],
+        label: label,
+        type: "Object",
+        map: (node) => {
+          try {
+            return this.attribute_node_value_by_id(
+              node,
+              timeDateUtil._networkCDCIdentified,
+              false,
+              false,
+              true
+            );
+          }
+          catch {
+            return kGlobals.missing.label;
+          }
+        }  
+      };
+    }
+
+    define_attribute_sel_mjc_date_identified_12mo(label) {
+      return {
+        depends: [],
+        label: label,
+        type: "Date",
+        map: (node) => {
+          // will be dynamically injected into node every time a MJ ClusterOI is viewed
+          return kGlobals.missing.label;
+        }
+      };
+    }
+
+    define_attribute_mjc_date_identified_12mo(label) {
+      return {
+        depends: [],
+        label: label,
+        type: "Object",
+        map: (node) => {
+          try {
+            return this.attribute_node_value_by_id(
+              node,
+              timeDateUtil._networkCDCIdentified_12Mo,
+              false,
+              false,
+              true
+            );
+          }
+          catch {
+            return kGlobals.missing.label;
+          }
+        }  
       };
     }
 
@@ -3105,9 +3161,9 @@ class HIVTxNetwork {
      * @param {*} label : use this label
      * @returns attribute definition dict
      */
-    define_attribute_dx_last_year(label) {
+    define_attribute_dx_12mo(label) {
       return {
-        depends: [timeDateUtil._networkCDCLastYearField],
+        depends: [timeDateUtil._networkCDCLast12Mo],
         label: label,
         type: "String",
         enum: ["Yes", "No"],
@@ -3115,7 +3171,30 @@ class HIVTxNetwork {
           try {
             return this.attribute_node_value_by_id(
               node,
-              timeDateUtil._networkCDCLastYearField,
+              timeDateUtil._networkCDCLast12Mo,
+              false,
+              false,
+              true
+            );
+          }
+          catch {
+            return kGlobals.missing.label;
+          }
+        },
+      };
+    }
+
+    define_attribute_dx_36mo(label) {
+      return {
+        depends: [timeDateUtil._networkCDCLast36Mo],
+        label: label,
+        type: "String",
+        enum: ["Yes", "No"],
+        map: (node) => {
+          try {
+            return this.attribute_node_value_by_id(
+              node,
+              timeDateUtil._networkCDCLast36Mo,
               false,
               false,
               true

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -2636,12 +2636,15 @@ class HIVTxNetwork {
     });
   }
 
-  MJCloadOwnPrioritySets(options) {
+  MJCloadOwnPrioritySets(options, callback) {
     if (this.isMJCNetwork && options["own-priority-sets-url"]) {
       this.own_priority_set_url = options["own-priority-sets-url"];
       this.fetch_priority_sets(this.own_priority_set_url, (results) => {
         this.own_defined_priority_groups = results;
+        callback();
       });
+    } else {
+      callback();
     }
   }
 
@@ -3467,7 +3470,7 @@ class HIVTxNetwork {
       for networks that have multiple sequences per individual, this function
       will reduce the list of node records to only include those that have
       attribute data. If more than one node has attribute data, the first one
-      (chosen based on the sorting order when this.primary_key_list was initialized)
+      (chosen based on the sorting order whfen this.primary_key_list was initialized)
       is returned.
     
     */
@@ -3501,6 +3504,7 @@ class HIVTxNetwork {
 
     aggregate_indvidual_level_records(node_list) {
       if (this.isMJCNetwork) {
+        // TODO: improve this to actually merge the node attributes
         return _.uniq(node_list, (n) => n.id ?? n.name);
       }
       node_list = node_list || this.json.Nodes;

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -40,7 +40,7 @@ class HIVTxNetwork {
     this.primary_key = _.isFunction(primary_key_function)
       ? primary_key_function
       : (node) => {
-        if (this.isMJCNetwork && !node.id) {
+        if (!node.id) {
           return node.name;
         }
         const i = node.id.indexOf("|");
@@ -902,8 +902,8 @@ class HIVTxNetwork {
     });
   };
 
-  priority_groups_compute_overlap_mjc = (mjc_groups, overlap_groups) => {
-    this.priority_node_overlap = {};
+  priority_groups_compute_overlap_mjc = (mjc_groups, overlap_groups, output_key) => {
+    this[output_key] = {};
 
     if (!mjc_groups || !overlap_groups) {
       return;
@@ -915,21 +915,21 @@ class HIVTxNetwork {
     // Also keep sizes for overlap_groups for superset/duplicate checks
     var size_by_overlap = {};
 
-    // 1) Build priority_node_overlap from overlap_groups (entity => Set of overlap PG names)
+    // Build this[output_key] from overlap_groups (entity => Set of overlap PG names)
     _.each(overlap_groups, (pg) => {
       const ents = this.aggregate_indvidual_level_records(pg.nodes);
       size_by_overlap[pg.name] = ents.length;
 
       _.each(ents, (n) => {
         const entity_id = this.entity_id(n);
-        if (!(entity_id in this.priority_node_overlap)) {
-          this.priority_node_overlap[entity_id] = new Set();
+        if (!(entity_id in this[output_key])) {
+          this[output_key][entity_id] = new Set();
         }
-        this.priority_node_overlap[entity_id].add(pg.name);
+        this[output_key][entity_id].add(pg.name);
       });
     });
 
-    // 3) For each mjc group, compute overlap only considering nodes that are present in overlap_groups
+    // For each mjc group, compute overlap only considering nodes that are present in overlap_groups
     _.each(mjc_groups, (pg) => {
       const overlap = {
         sets: new Set(),
@@ -943,9 +943,9 @@ class HIVTxNetwork {
         const entity_id = this.entity_id(n);
 
         // Only care about nodes in mjc_groups that are present in overlap_groups
-        if (entity_id in this.priority_node_overlap && this.priority_node_overlap[entity_id].size > 0) {
+        if (entity_id in this[output_key] && this[output_key][entity_id].size > 1) {
           overlap.nodes++;
-          this.priority_node_overlap[entity_id].forEach((overlap_pg_name) => {
+          this[output_key][entity_id].forEach((overlap_pg_name) => {
             // Collect counts per PG (these are names from overlap_groups)
             if (!(overlap_pg_name in by_set_count)) {
               by_set_count[overlap_pg_name] = [];
@@ -2626,6 +2626,7 @@ class HIVTxNetwork {
       });
 
       clustersOfInterest.draw_priority_set_table(this);
+      clustersOfInterest.draw_priority_set_table(this, null, null, true); // null just uses defaults (for archived MJ clusterOI)
       if (
         this.showing_diff &&
         this.has_network_attribute("subcluster_or_priority_node")
@@ -2646,6 +2647,44 @@ class HIVTxNetwork {
     } else {
       callback();
     }
+  }
+
+  priority_groups_archive_mjc_set(name, archived) {
+    // currently only for MJC networks
+    if (!this.isMJCNetwork) {
+      return;
+    }
+    const pg = _.find(this.defined_priority_groups, (pg) => pg.name === name);
+    if (!pg) {
+      console.warn("Could not find priority group with name " + name);
+      return;
+    }
+
+    pg.archived = archived;
+
+    fetch(this.mjc_archive_url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: pg.name,
+        archived: pg.archived,
+      }),
+    })
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(
+          "Network response was not ok: " + response.statusText
+        );
+      }
+      return response.json();
+    })
+    .then((data) => {
+      clustersOfInterest.draw_priority_set_table(this);
+      clustersOfInterest.draw_priority_set_table(this, null, null, true);
+
+    });
   }
 
     /**  add an attribute description

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -902,23 +902,23 @@ class HIVTxNetwork {
     });
   };
 
-  priority_groups_compute_overlap_mjc = (mjc_groups, own_groups) => {
+  priority_groups_compute_overlap_mjc = (mjc_groups, overlap_groups) => {
     this.priority_node_overlap = {};
 
-    if (!mjc_groups || !own_groups) {
+    if (!mjc_groups || !overlap_groups) {
       return;
     }
 
     // Build a map of entity lists & sizes for mjc_groups (we will iterate mjc_groups later)
     var size_by_pg = {};
 
-    // Also keep sizes for own_groups for superset/duplicate checks
-    var size_by_own = {};
+    // Also keep sizes for overlap_groups for superset/duplicate checks
+    var size_by_overlap = {};
 
-    // 1) Build priority_node_overlap from own_groups (entity => Set of own PG names)
-    _.each(own_groups, (pg) => {
+    // 1) Build priority_node_overlap from overlap_groups (entity => Set of overlap PG names)
+    _.each(overlap_groups, (pg) => {
       const ents = this.aggregate_indvidual_level_records(pg.nodes);
-      size_by_own[pg.name] = ents.length;
+      size_by_overlap[pg.name] = ents.length;
 
       _.each(ents, (n) => {
         const entity_id = this.entity_id(n);
@@ -929,7 +929,7 @@ class HIVTxNetwork {
       });
     });
 
-    // 3) For each mjc group, compute overlap only considering nodes that are present in own_groups
+    // 3) For each mjc group, compute overlap only considering nodes that are present in overlap_groups
     _.each(mjc_groups, (pg) => {
       const overlap = {
         sets: new Set(),
@@ -942,29 +942,29 @@ class HIVTxNetwork {
       _.each(pg.nodes, (n) => {
         const entity_id = this.entity_id(n);
 
-        // Only care about nodes in mjc_groups that are present in own_groups
+        // Only care about nodes in mjc_groups that are present in overlap_groups
         if (entity_id in this.priority_node_overlap && this.priority_node_overlap[entity_id].size > 0) {
           overlap.nodes++;
-          this.priority_node_overlap[entity_id].forEach((own_pg_name) => {
-            // Collect counts per owning PG (these are names from own_groups)
-            if (!(own_pg_name in by_set_count)) {
-              by_set_count[own_pg_name] = [];
+          this.priority_node_overlap[entity_id].forEach((overlap_pg_name) => {
+            // Collect counts per PG (these are names from overlap_groups)
+            if (!(overlap_pg_name in by_set_count)) {
+              by_set_count[overlap_pg_name] = [];
             }
-            by_set_count[own_pg_name].push(entity_id);
+            by_set_count[overlap_pg_name].push(entity_id);
 
-            overlap.sets.add(own_pg_name);
+            overlap.sets.add(overlap_pg_name);
           });
         }
       });
 
-      // Determine supersets/duplicates: if an own_group contains ALL entities of this mjc_group (within our intersection),
+      // Determine supersets/duplicates: if an overlap_group contains ALL entities of this mjc_group (within our intersection),
       // then it's either a superset or a duplicate (same size).
-      _.each(by_set_count, (nodes, own_name) => {
+      _.each(by_set_count, (nodes, overlap_name) => {
         if (nodes.length == size_by_pg[pg.name]) {
-          if (size_by_own[own_name] == size_by_pg[pg.name]) {
-            overlap.duplicates.push(own_name);
+          if (size_by_overlap[overlap_name] == size_by_pg[pg.name]) {
+            overlap.duplicates.push(overlap_name);
           } else {
-            overlap.supersets.push(own_name);
+            overlap.supersets.push(overlap_name);
           }
         }
       });
@@ -972,7 +972,7 @@ class HIVTxNetwork {
       // assign overlap summary to the mjc group
       pg.overlap = {
         nodes: overlap.nodes,
-        // sets = number of distinct own_groups that share nodes with this mjc_group
+        // sets = number of distinct overlap_groups that share nodes with this mjc_group
         sets: overlap.sets.size,
         superset: overlap.supersets,
         duplicate: overlap.duplicates,
@@ -2636,11 +2636,11 @@ class HIVTxNetwork {
     });
   }
 
-  MJCloadOwnPrioritySets(options, callback) {
-    if (this.isMJCNetwork && options["own-priority-sets-url"]) {
-      this.own_priority_set_url = options["own-priority-sets-url"];
-      this.fetch_priority_sets(this.own_priority_set_url, (results) => {
-        this.own_defined_priority_groups = results;
+  loadOverlapPrioritySets(options, callback) {
+    if (options["overlap-priority-sets-url"]) {
+      this.overlap_priority_set_url = options["overlap-priority-sets-url"];
+      this.fetch_priority_sets(this.overlap_priority_set_url, (results) => {
+        this.overlap_defined_priority_groups = results;
         callback();
       });
     } else {

--- a/src/timeDateUtil.js
+++ b/src/timeDateUtil.js
@@ -1,8 +1,11 @@
 var d3 = require("d3");
 
 const _networkCDCDateField = "hiv_aids_dx_dt";
-const _networkCDCLastYearField = "hiv_aids_dx_dt_last_year";
+const _networkCDCLast12Mo = "hiv_aids_dx_dt_12mo";
+const _networkCDCLast36Mo = "hiv_aids_dx_dt_36mo";
 const _networkCDCMonthYearField = "hiv_aids_dx_dt_month_year";
+const _networkCDCIdentified = "mjc_date_identified";
+const _networkCDCIdentified_12Mo = "mjc_date_identified_12mo";
 
 const _networkTimeQuery = /([0-9]{8}):([0-9]{8})/i;
 
@@ -108,8 +111,11 @@ function n_months_ago(reference_date, months) {
 module.exports = {
   hivtrace_date_or_na_if_missing,
   _networkCDCDateField,
-  _networkCDCLastYearField,
+  _networkCDCLast12Mo,
+  _networkCDCLast36Mo,
   _networkCDCMonthYearField,
+  _networkCDCIdentified,
+  _networkCDCIdentified_12Mo,
   _networkTimeQuery,
   getClusterTimeScale,
   getCurrentDate,


### PR DESCRIPTION
A minimal refactor of code (also with some slightly formatting fixes) to create support for the Multijurisdiction clusters of interest (MJ ClusterOI) network pages. Developed in parallel with https://github.com/veg/hivtrace-secure/pull/451.

**Also has a critical bug fix to ensure history tracking is properly done for clusters of interest.**