### PR TITLE
chore: Remove debug console.log statements

### DIFF
--- a/src/clusternetwork.js
+++ b/src/clusternetwork.js
@@ -1536,8 +1536,6 @@ var hivtrace_cluster_network_graph = function (
           sub.recent_nodes = [];
 
           const future_date = new Date(start_date.getTime() + 1e13);
-          if (sub.cluster_id == "2211.1")
-            console.log(sub, rr_cluster, subcluster_json);
 
           _.each(rr_cluster, (recent_cluster) => {
             var priority_nodes = _.groupBy(recent_cluster, (n) =>

--- a/src/clustersOfInterest.js
+++ b/src/clustersOfInterest.js
@@ -625,7 +625,6 @@ function open_editor(
       };
 
       panel_object._append_node = function (node) {
-        console.log(node, modifiedDate, createdDate);
         if (!("_priority_set_date" in node)) {
           node["_priority_set_date"] = modifiedDate || createdDate;
         }
@@ -719,8 +718,6 @@ function open_editor(
             panel_object._append_node(valid_ids[n.id]);
             existing_ids[n.id] = 1;
             need_update = true;
-          } else {
-            console.log("***", n);
           }
         });
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -441,9 +441,7 @@ function exportColorScheme(uniqValues, colorizer) {
 
 function copyToClipboard(text) {
   navigator.clipboard.writeText(text).then(
-    () => {
-      console.log("Copying to clipboard was successful!");
-    },
+    () => {},
     (err) => {
       console.error("Could not copy text: ", err);
     }

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -462,7 +462,6 @@ class HIVTxNetwork {
       //console.log (misc.hivtrace_cluster_depthwise_traversal (c95.Nodes, c95.Edges, (d)=>d.length <= reduce_distance_within));
 
       let null_size = nodes_to_delete.size;
-      console.log("Marked ", null_size, " nodes in null clusters");
 
       _.each(complete_clusters, (cluster, cluster_index) => {
         if (cluster.length > 1) {
@@ -2633,10 +2632,6 @@ class HIVTxNetwork {
 
       var extension = {};
       extension[key] = computed;
-
-      if (key == "priority_set") {
-        console.log();
-      }
 
       _.extend(this.json[kGlobals.network.GraphAttrbuteID], extension);
 

--- a/src/timeDateUtil.js
+++ b/src/timeDateUtil.js
@@ -69,7 +69,7 @@ function hivtrace_date_or_na_if_missing(date, formatter) {
     try {
       return formatter(date);
     } catch {
-      console.log(date);
+      // Invalid date format
     }
   }
   return "N/A";


### PR DESCRIPTION
## Summary
- Remove extraneous debug console.log statements that were cluttering the browser console
- Cleaned up 7 debug logs across 5 files (clusternetwork.js, clustersOfInterest.js, helpers.js, hiv_tx_network.js, timeDateUtil.js)
- Kept intentional error-handling logs and those with eslint-disable comments

## Test plan
- [ ] Verify the application loads without errors
- [ ] Check browser console is cleaner without debug messages