### PR TITLE
Add MJC-specific endpoint for ClusterOI description updates

### DIFF
--- a/src/clusternetwork.js
+++ b/src/clusternetwork.js
@@ -99,6 +99,7 @@ var hivtrace_cluster_network_graph = function (
   self.process_multiple_sequences();
 
   self.isMJCNetwork = options && options["is-mjc-network"] ? true : false;
+  self.mjcUUID = self.isMJCNetwork ? options["mjc-uuid"] || null : null;
   self.MJCVariables = self.isMJCNetwork ? options["mjc-variables"] || {} : {};
 
   self._is_CDC_ = options && options["no_cdc"] ? false : true;

--- a/src/clusternetwork.js
+++ b/src/clusternetwork.js
@@ -84,7 +84,7 @@ var hivtrace_cluster_network_graph = function (
 
   /** Not primary networks are individual cluster/subcluster views.
       They don't interfere with the primary network object, and UI elements
-  
+
    */
 
   const izPrimaryGraph = network.check_network_option(
@@ -171,8 +171,9 @@ var hivtrace_cluster_network_graph = function (
       options,
       "priority-table-writeback"
     );
-    if (self.priority_set_table)
+    if (self.priority_set_table) {
       self.priority_set_table = d3.select(self.priority_set_table);
+    }
   } else {
     self.priority_set_table = null;
     self.priority_set_table_write = null;
@@ -190,7 +191,7 @@ var hivtrace_cluster_network_graph = function (
     options["init_code"].call(null, self, options);
   }
 
-  /** Whenever the code creates a DOM element, it will be done using this prefix 
+  /** Whenever the code creates a DOM element, it will be done using this prefix
       to generate element IDs
    */
 
@@ -202,7 +203,7 @@ var hivtrace_cluster_network_graph = function (
 
   /** Retrieve additional columns (as dict, see comments further down in the code)
       for the "clusters" table
-  
+
    */
   self.extra_cluster_table_columns = network.check_network_option(
     options,
@@ -588,7 +589,7 @@ var hivtrace_cluster_network_graph = function (
 
     if (self.has_multiple_sequences) {
       /**
-            20241030 SLKP 
+            20241030 SLKP
             Perform a greedy collapse of all the sequences that map to the same primary key
             For a reduced cluster view
         */
@@ -1235,8 +1236,9 @@ var hivtrace_cluster_network_graph = function (
       custom_name || "Subcluster " + cluster.cluster_id,
       view_sub_options
     );
-    if (!view_sub_options.skip_recent_rapid)
+    if (!view_sub_options.skip_recent_rapid) {
       cluster_view.handle_attribute_categorical("subcluster_or_priority_node");
+    }
     return cluster_view;
 
     /*var selector =
@@ -1290,7 +1292,7 @@ var hivtrace_cluster_network_graph = function (
     recent_months,
     start_date
   ) {
-    /* 
+    /*
         values for priority_flag
             0: 0.5% subcluster
             1: last 12 months NOT in a priority cluster
@@ -1301,11 +1303,11 @@ var hivtrace_cluster_network_graph = function (
             5: date present but is between 1900 and start_date
             6: date missing
             7: in 0.5% cluster 12<dx<36 months but not a CoI
-            
-            
+
+
         SLKP 20221128:
             Add a calculation for simple classification of priority clusters
-            
+
             0: not in a national priority CoI
             1: IN a national priority CoI ≤12 months
             2: IN a national priority CoI 12 - 36 months
@@ -1406,7 +1408,7 @@ var hivtrace_cluster_network_graph = function (
         /** all clusters with more than one member connected at 'threshold' edge length */
         /** 20241031 SLKP
             Here, if there's more than one sequence per entity,
-            additional filtering will take place to NOT retain 
+            additional filtering will take place to NOT retain
             sub-clusters that are comprised entirely of sequences from the same entity
         **/
 
@@ -2146,7 +2148,10 @@ var hivtrace_cluster_network_graph = function (
       if (priority_group) {
         cluster_nodes = self.priority_groups_find_by_name(priority_group);
         if (cluster_nodes) {
-          if (self.has_multiple_sequences) {
+          // For MJC networks, use nodes array directly since node_objects only contains local nodes
+          if (self.isMJCNetwork) {
+            cluster_nodes = cluster_nodes.nodes || [];
+          } else if (self.has_multiple_sequences) {
             cluster_nodes = self.aggregate_indvidual_level_records(
               cluster_nodes.node_objects
             );
@@ -2196,25 +2201,66 @@ var hivtrace_cluster_network_graph = function (
           });
         });
       } else {
-        _.each(cluster_nodes, (node) => {
-          var patient_record = the_list.append("li");
-          patient_record
-            .append("code")
-            .text(this.cleanRedacted(this.entity_id(node)));
-          var patient_list = patient_record
-            .append("dl")
-            .classed("dl-horizontal", true);
-          _.each(column_ids, (column) => {
-            patient_list
-              .append("dt")
-              .text(column.label || column.raw_attribute_key);
-            patient_list
-              .append("dd")
-              .text(
-                self.attribute_node_value_by_id(node, column.raw_attribute_key)
-              );
+        // For MJC networks, nodes have a simpler structure directly from the API
+        if (self.isMJCNetwork) {
+          const mjcFields = [
+            { key: "jurisdiction", label: "Jurisdiction" },
+            { key: "dx_date", label: "Diagnosis Date" },
+            { key: "added", label: "Date Added to MJ ClusterOI" },
+            { key: "dx_within_12mo", label: "Diagnosed in Last 12 Months" },
+          ];
+          _.each(cluster_nodes, (node) => {
+            var patient_record = the_list.append("li");
+            patient_record
+              .append("code")
+              .text(this.cleanRedacted(node.name || "Unknown"));
+            var patient_list = patient_record
+              .append("dl")
+              .classed("dl-horizontal", true);
+            _.each(mjcFields, (field) => {
+              let value = node[field.key];
+              // Format dates nicely
+              if (field.key.includes("date") || field.key === "added") {
+                try {
+                  value = value
+                    ? timeDateUtil.DateViewFormatExport(new Date(value))
+                    : "N/A";
+                } catch (e) {
+                  value = value || "N/A";
+                }
+              }
+              // Format boolean
+              if (typeof value === "boolean") {
+                value = value ? "Yes" : "No";
+              }
+              patient_list.append("dt").text(field.label);
+              patient_list.append("dd").text(value || "N/A");
+            });
           });
-        });
+        } else {
+          _.each(cluster_nodes, (node) => {
+            var patient_record = the_list.append("li");
+            patient_record
+              .append("code")
+              .text(this.cleanRedacted(this.entity_id(node)));
+            var patient_list = patient_record
+              .append("dl")
+              .classed("dl-horizontal", true);
+            _.each(column_ids, (column) => {
+              patient_list
+                .append("dt")
+                .text(column.label || column.raw_attribute_key);
+              patient_list
+                .append("dd")
+                .text(
+                  self.attribute_node_value_by_id(
+                    node,
+                    column.raw_attribute_key
+                  )
+                );
+            });
+          });
+        }
       }
     };
 
@@ -2256,9 +2302,28 @@ var hivtrace_cluster_network_graph = function (
       $(self.get_ui_element_selector_by_role("cluster_list", true)).on(
         "show.bs.modal",
         (event) => {
-          var link_clicked = $(event.relatedTarget);
-          var cluster_id = link_clicked.data("cluster");
-          var priority_list = link_clicked.data("priority_set");
+          var $modal = $(event.target);
+          var link_clicked = event.relatedTarget
+            ? $(event.relatedTarget)
+            : null;
+
+          // Try to get priority_set from relatedTarget first, then from modal data (for programmatic triggers)
+          var cluster_id = link_clicked ? link_clicked.data("cluster") : null;
+          var priority_list = link_clicked
+            ? link_clicked.data("priority_set")
+            : null;
+
+          // Fall back to modal data for programmatic triggers
+          if (!priority_list) {
+            priority_list = $modal.data("priority_set_trigger");
+          }
+
+          console.log(
+            "Modal show - priority_list:",
+            priority_list,
+            "cluster_id:",
+            cluster_id
+          );
 
           var modal = d3.select(
             self.get_ui_element_selector_by_role("cluster_list", true)
@@ -2571,9 +2636,12 @@ var hivtrace_cluster_network_graph = function (
       }
     );
 
-    if (button_bar_ui) {
+    // Setup cluster list view for both regular networks (with button bar) and MJC networks
+    if (button_bar_ui || self.isMJCNetwork) {
       self._setup_cluster_list_view();
+    }
 
+    if (button_bar_ui) {
       var cluster_ui_container = d3.select(
         self.get_ui_element_selector_by_role("cluster_operations_container")
       );
@@ -2789,12 +2857,13 @@ var hivtrace_cluster_network_graph = function (
         cluster_commands.push([
           "Add filtered objects to cluster of interest",
           function (item) {
-            if (clustersOfInterest.get_editor())
+            if (clustersOfInterest.get_editor()) {
               clustersOfInterest
                 .get_editor()
                 .append_node_objects(
                   _.filter(self.json["Nodes"], (n) => n.match_filter)
                 );
+            }
           },
           clustersOfInterest.get_editor,
           "hivtrace-add-filtered-to-panel",
@@ -3873,13 +3942,15 @@ var hivtrace_cluster_network_graph = function (
                 if (
                   _.isObject(e.source) &&
                   HTX.HIVTxNetwork.is_new_node(e.source)
-                )
+                ) {
                   return "Newly added";
+                }
                 if (
                   _.isObject(e.target) &&
                   HTX.HIVTxNetwork.is_new_node(e.target)
-                )
+                ) {
                   return "Newly added";
+                }
 
                 return e.attributes.indexOf("added-to-prior") >= 0
                   ? "Newly added"
@@ -8714,6 +8785,6 @@ var hivtrace_cluster_network_graph = function (
 };
 
 export {
-  hivtrace_cluster_network_graph as clusterNetwork,
   hivtrace_cluster_depthwise_traversal as computeCluster,
+  hivtrace_cluster_network_graph as clusterNetwork,
 };

--- a/src/clustersOfInterest.js
+++ b/src/clustersOfInterest.js
@@ -1064,50 +1064,83 @@ function open_editor(
 function handle_inline_confirm(this_button, generator, text, action, disabled) {
   this_button = $(this_button.node());
   if (this_button.data("popover_shown") !== "shown") {
-    const popover = this_button
-      .popover({
-        sanitize: false,
-        placement: "right",
-        container: "body",
-        html: true,
-        content: generator,
-        trigger: "manual",
-      })
-      .on("shown.bs.popover", function (e) {
-        var clicked_object = d3.select(this);
-        var popover_div = d3.select(
-          "#" + clicked_object.attr("aria-describedby")
-        );
-        var textarea_element = popover_div.selectAll(
-          misc.get_ui_element_selector_by_role("priority-description-form")
-        );
-        var button_element = popover_div.selectAll(
-          misc.get_ui_element_selector_by_role("priority-description-save")
-        );
-        textarea_element.text(text);
-        if (disabled) textarea_element.attr("disabled", true);
-        button_element.on("click", (d) => {
-          action($(textarea_element.node()).val());
-          d3.event.preventDefault();
-          this_button.click();
+    try {
+      const popover = this_button
+        .popover({
+          sanitize: false,
+          placement: "right",
+          container: "body",
+          html: true,
+          content: generator,
+          trigger: "manual",
+        })
+        .on("shown.bs.popover", function (e) {
+          var clicked_object = d3.select(this);
+          var popover_div = d3.select(
+            "#" + clicked_object.attr("aria-describedby")
+          );
+          var textarea_element = popover_div.selectAll(
+            misc.get_ui_element_selector_by_role("priority-description-form")
+          );
+          var button_element = popover_div.selectAll(
+            misc.get_ui_element_selector_by_role("priority-description-save")
+          );
+          textarea_element.text(text);
+          if (disabled) textarea_element.attr("disabled", true);
+          button_element.on("click", (d) => {
+            action($(textarea_element.node()).val());
+            d3.event.preventDefault();
+            this_button.click();
+          });
+          button_element = popover_div.selectAll(
+            misc.get_ui_element_selector_by_role("priority-description-dismiss")
+          );
+          button_element.on("click", (d) => {
+            d3.event.preventDefault();
+            this_button.click();
+          });
         });
-        button_element = popover_div.selectAll(
-          misc.get_ui_element_selector_by_role("priority-description-dismiss")
-        );
-        button_element.on("click", (d) => {
-          d3.event.preventDefault();
-          this_button.click();
-        });
-      });
 
-    popover.popover("show");
-    this_button.data("popover_shown", "shown");
-    this_button.off("hidden.bs.popover").on("hidden.bs.popover", function () {
-      $(this).data("popover_shown", "hidden");
-    });
+      popover.popover("show");
+      this_button.data("popover_shown", "shown");
+
+      // Fix popover visibility (Bootstrap fade transition workaround)
+      setTimeout(() => {
+        var popoverId = this_button.attr("aria-describedby");
+        if (popoverId) {
+          var popoverEl = $("#" + popoverId);
+          popoverEl.removeClass("fade").addClass("show in");
+          popoverEl.css({
+            "z-index": "99999",
+            opacity: "1",
+            display: "block",
+          });
+        }
+      }, 50);
+
+      this_button.off("hidden.bs.popover").on("hidden.bs.popover", function () {
+        $(this).data("popover_shown", "hidden");
+      });
+    } catch (e) {
+      console.error("Error creating/showing popover:", e);
+    }
   } else {
     this_button.data("popover_shown", "hidden");
-    this_button.popover("destroy");
+    // Bootstrap 3 uses "destroy", Bootstrap 4/5 uses "dispose"
+    try {
+      this_button.popover("destroy");
+    } catch (e) {
+      try {
+        this_button.popover("dispose");
+      } catch (e2) {
+        // If neither works, try to hide and remove manually
+        this_button.popover("hide");
+        var popoverId = this_button.attr("aria-describedby");
+        if (popoverId) {
+          $("#" + popoverId).remove();
+        }
+      }
+    }
   }
 }
 
@@ -1204,10 +1237,66 @@ function _action_drop_down(self, pg) {
     }
     dropdown.push({
       label: "View nodes in this cluster of interest",
-      data: {
-        toggle: "modal",
-        target: misc.get_ui_element_selector_by_role("cluster_list"),
-        priority_set: pg.name,
+      action: function (button, value) {
+        const modalSelector = misc.get_ui_element_selector_by_role(
+          "cluster_list",
+          true
+        );
+        const $modal = $(modalSelector);
+
+        // Store priority set name for the modal handler to use
+        $modal.data("priority_set_trigger", pg.name);
+
+        // Manually trigger the show.bs.modal event and show the modal
+        // This is a workaround for Bootstrap modal not working
+        $modal.trigger("show.bs.modal");
+
+        // Manually add Bootstrap 3 modal classes and styles
+        $modal
+          .addClass("in")
+          .css("display", "block")
+          .attr("aria-hidden", "false");
+
+        // Add backdrop
+        if (!$(".modal-backdrop").length) {
+          $("body").append('<div class="modal-backdrop fade in"></div>');
+          $("body").addClass("modal-open");
+        }
+
+        // Helper function to close modal
+        const closeModal = function () {
+          $modal
+            .removeClass("in")
+            .css("display", "none")
+            .attr("aria-hidden", "true");
+          $(".modal-backdrop").remove();
+          $("body").removeClass("modal-open");
+          $modal.trigger("hidden.bs.modal");
+        };
+
+        // Bind close handlers (unbind first to prevent duplicates)
+        $modal
+          .find('[data-dismiss="modal"]')
+          .off("click.mjcmodal")
+          .on("click.mjcmodal", closeModal);
+
+        // Also close on backdrop click
+        $modal.off("click.mjcmodal").on("click.mjcmodal", function (e) {
+          if ($(e.target).is($modal)) {
+            closeModal();
+          }
+        });
+
+        // Close on escape key
+        $(document)
+          .off("keydown.mjcmodal")
+          .on("keydown.mjcmodal", function (e) {
+            if (e.keyCode === 27) {
+              // Escape
+              closeModal();
+              $(document).off("keydown.mjcmodal");
+            }
+          });
       },
     });
   }
@@ -1340,6 +1429,21 @@ function draw_priority_set_table(self, container, priority_groups) {
           hidden:
             self.isMJCNetwork &&
             self.MJCVariables.mjcCurrentSizeEnabled === false,
+        },
+        {
+          value: "Size (mine)",
+          width: 100,
+          sort: "value",
+          help: "Number of nodes from your jurisdiction in this cluster",
+          hidden: (function () {
+            console.log(
+              "Size (mine) column - isMJCNetwork:",
+              self.isMJCNetwork,
+              "hidden:",
+              !self.isMJCNetwork
+            );
+            return !self.isMJCNetwork;
+          })(),
         },
         {
           value: "Priority",
@@ -1491,8 +1595,11 @@ function draw_priority_set_table(self, container, priority_groups) {
         },
         {
           // size / new nodes
+          // For MJC networks, use pg.nodes.length since node_objects only contains local nodes
           value: [
-            self.unique_entity_list(pg.node_objects).length,
+            self.isMJCNetwork
+              ? pg.nodes.length
+              : self.unique_entity_list(pg.node_objects).length,
             _.chain(pg.nodes)
               .groupBy((n) => self.entity_id_from_string(n.name))
               .mapObject((v) =>
@@ -1529,6 +1636,12 @@ function draw_priority_set_table(self, container, priority_groups) {
           hidden:
             self.isMJCNetwork &&
             self.MJCVariables.mjcCurrentSizeEnabled === false,
+        },
+        {
+          // size in my jurisdiction (MJC only)
+          width: 100,
+          value: pg.size_in_jurisdiction || 0,
+          hidden: !self.isMJCNetwork,
         },
         {
           // meets priority definition
@@ -1705,7 +1818,7 @@ function draw_priority_set_table(self, container, priority_groups) {
       }
       this_row[1].actions = _.flatten(this_row[1].actions);
       //console.log (this_row[0]);
-      if (pg.not_in_network.length) {
+      if (pg.not_in_network && pg.not_in_network.length) {
         this_row[2]["actions"] = [
           {
             text: String(pg.not_in_network.length) + " removed",

--- a/src/column_definitions.js
+++ b/src/column_definitions.js
@@ -111,6 +111,7 @@ function secure_hiv_trace_subcluster_columns(self) {
           actions: function (item, value) {
             if (
               !clustersOfInterest.get_editor() ||
+              !cluster.recent_nodes ||
               cluster.recent_nodes.length === 0
             ) {
               return null;
@@ -191,7 +192,7 @@ function secure_hiv_trace_subcluster_columns(self) {
         definition["actions"] = function (item, value) {
           let result = [];
 
-          if (cluster.priority_score.length > 0) {
+          if (cluster.priority_score && cluster.priority_score.length > 0) {
             result = result.concat(
               _.map(cluster.priority_score, (c) => ({
                 icon: "fa-question",

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -800,7 +800,15 @@ class HIVTxNetwork {
   /** lookup a CoI by name; null if not found */
   priority_groups_find_by_name = function (name) {
     if (this.defined_priority_groups) {
-      return _.find(this.defined_priority_groups, (g) => g.name === name);
+      const result = _.find(
+        this.defined_priority_groups,
+        (g) => g.name === name
+      );
+      if (result) return result;
+    }
+    // For MJC networks, also check own_defined_priority_groups
+    if (this.isMJCNetwork && this.own_defined_priority_groups) {
+      return _.find(this.own_defined_priority_groups, (g) => g.name === name);
     }
     return null;
   };
@@ -2604,7 +2612,8 @@ class HIVTxNetwork {
         true
       );
 
-      if (!this.priority_set_table_writeable) {
+      // Skip read-only warning for MJC networks (they are read-only by design)
+      if (!this.priority_set_table_writeable && !this.isMJCNetwork) {
         const rationale =
           is_writeable === "old"
             ? "the network is <b>older</b> than some of the Clusters of Interest"

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -1366,7 +1366,27 @@ class HIVTxNetwork {
     let pg_to_update = this.priority_groups_find_by_name(name);
     if (pg_to_update) {
       pg_to_update.description = description;
-      this.priority_groups_update_node_sets(name, "update");
+
+      // For MJC networks, use MJC-specific endpoint
+      if (this.isMJCNetwork && this.mjcUUID) {
+        const url = `/mjc/results/${
+          this.mjcUUID
+        }/clusteroi/${encodeURIComponent(name)}/description`;
+        d3.text(url)
+          .header("Content-Type", "application/json")
+          .send(
+            "PUT",
+            JSON.stringify({ description: description }),
+            (error, data) => {
+              if (error) {
+                console.error("Error saving MJC ClusterOI description:", error);
+              }
+            }
+          );
+      } else {
+        this.priority_groups_update_node_sets(name, "update");
+      }
+
       if (update_table) {
         clustersOfInterest.draw_priority_set_table(this);
       }

--- a/src/misc.js
+++ b/src/misc.js
@@ -1376,8 +1376,10 @@ function hivtrace_plot_cluster_dynamics(
  * @returns {string} A CSS selector string targeting elements with the specified role.
 */
 
-function get_ui_element_selector_by_role(role) {
-  return ` [data-hivtrace-ui-role='${role}']`;
+function get_ui_element_selector_by_role(role, no_leading_space) {
+  // Leading space is for descendant selection, but should be omitted for Bootstrap targets
+  const prefix = no_leading_space ? "" : " ";
+  return `${prefix}[data-hivtrace-ui-role='${role}']`;
 }
 
 module.exports = {

--- a/src/tables.js
+++ b/src/tables.js
@@ -400,36 +400,44 @@ function format_a_cell(data, index, item, priority_set_editor) {
               }
 
               dropdown_list = dropdown_list.selectAll("li").data(items);
-              dropdown_list.enter().append("li");
-              dropdown_list.each(function (data, i) {
-                var handle_change = d3
-                  .select(this)
-                  .append("a")
-                  .attr("href", "#")
-                  .text((data) => get_item_text(data));
-                if (_.has(data, "data") && data["data"]) {
-                  //let element = $(this_button.node());
-                  _.each(data.data, (v, k) => {
-                    handle_change.attr("data-" + k, v);
-                  });
-                }
-                handle_change.on("click", (d) => {
-                  if (_.has(d, "action") && d["action"]) {
-                    d["action"](this_button, d["label"]);
-                  } else if (b.action) {
-                    b.action(this_button, get_item_text(d));
+              dropdown_list
+                .enter()
+                .append("li")
+                .each(function (data, i) {
+                  var handle_change = d3
+                    .select(this)
+                    .append("a")
+                    .attr("href", "#")
+                    .text((data) => get_item_text(data));
+                  if (_.has(data, "data") && data["data"]) {
+                    //let element = $(this_button.node());
+                    _.each(data.data, (v, k) => {
+                      handle_change.attr("data-" + k, v);
+                    });
                   }
+                  handle_change.on("click", (d) => {
+                    // Only prevent default/propagation if there's a custom action handler
+                    if ((_.has(d, "action") && d["action"]) || b.action) {
+                      d3.event.preventDefault();
+                      d3.event.stopPropagation();
+                      if (_.has(d, "action") && d["action"]) {
+                        d["action"](this_button, d["label"]);
+                      } else if (b.action) {
+                        b.action(this_button, get_item_text(d));
+                      }
+                    }
+                  });
                 });
-              });
             } else {
               this_button = button_group
                 .append("button")
                 .classed("btn btn-default btn-xs", true);
-              if (b.action)
+              if (b.action) {
                 this_button.on("click", (e) => {
                   d3.event.preventDefault();
                   b.action(this_button, current_value);
                 });
+              }
             }
             if (b.icon) {
               this_button.append("i").classed("fa " + b.icon, true);


### PR DESCRIPTION
## Summary
- Add `mjcUUID` property to network options for MJC network identification
- Use dedicated MJC endpoint (`/mjc/results/{uuid}/clusteroi/{name}/description`) for saving ClusterOI descriptions in MJC networks
- Preserves existing behavior for non-MJC networks

## Test plan
- [ ] Verify ClusterOI description updates work in MJC networks
- [ ] Verify ClusterOI description updates still work in standard networks