### PR TITLE
fix(viz): migrate date handling to UTC to resolve display discrepancy

### DIFF
--- a/src/clusternetwork.js
+++ b/src/clusternetwork.js
@@ -416,8 +416,8 @@ var hivtrace_cluster_network_graph = function (
     ) {
       self.using_time_filter = timeDateUtil.getCurrentDate();
       self.warning_string += __("network_tab")["cluster_display_info"];
-      self.using_time_filter.setFullYear(
-        self.using_time_filter.getFullYear() - 1
+      self.using_time_filter.setUTCFullYear(
+        self.using_time_filter.getUTCFullYear() - 1
       );
       self.cluster_filtering_functions["recent"] = self.filter_time_period;
     }
@@ -3670,7 +3670,7 @@ var hivtrace_cluster_network_graph = function (
                 return {};
               }
 
-              determine_scaling(d, values, [d3.time.scale()]);
+              determine_scaling(d, values, [d3.time.scale.utc()]);
             }
             return d;
           }),
@@ -4696,8 +4696,7 @@ var hivtrace_cluster_network_graph = function (
     _.each(seed_nodes, (sn) => _.each(sn, (n) => (n.visited = false)));
 
     var beginning_of_time = timeDateUtil.getCurrentDate();
-    beginning_of_time.setFullYear(1900);
-
+    beginning_of_time.setUTCFullYear(1900);
     // unused var
     // const nodesD2 = _.map(full_subclusters, (fc, i) => hivtrace_cluster_depthwise_traversal(
     //   fc["Nodes"],
@@ -4714,9 +4713,11 @@ var hivtrace_cluster_network_graph = function (
     _.each(network_events, (DT) => {
       const event_date = timeDateUtil.DateViewFormatSlider.parse(DT);
       const event_date_m3y = timeDateUtil.DateViewFormatSlider.parse(DT);
-      event_date_m3y.setFullYear(event_date.getFullYear() - 3);
+      event_date_m3y.setUTCFullYear(event_date.getUTCFullYear() - 3);
+      event_date_m3y.setUTCHours(0, 0, 0, 0);
       const event_date_m1y = timeDateUtil.DateViewFormatSlider.parse(DT);
-      event_date_m1y.setFullYear(event_date.getFullYear() - 1);
+      event_date_m1y.setUTCFullYear(event_date.getUTCFullYear() - 1);
+      event_date_m1y.setUTCHours(0, 0, 0, 0);
       const n_filter = (n) =>
         self.filter_by_date(
           beginning_of_time,
@@ -8552,8 +8553,8 @@ var hivtrace_cluster_network_graph = function (
       self.using_time_filter = null;
     } else {
       self.using_time_filter = timeDateUtil.getCurrentDate();
-      self.using_time_filter.setFullYear(
-        self.using_time_filter.getFullYear() - 1
+      self.using_time_filter.setUTCFullYear(
+        self.using_time_filter.getUTCFullYear() - 1
       );
     }
 

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -1654,8 +1654,8 @@ class HIVTxNetwork {
     if (passed) {
       if (
         this._is_CDC_ &&
-        (parsed_value.getFullYear() < 1970 ||
-          parsed_value.getFullYear() > timeDateUtil.DateUpperBoundYear)
+        (parsed_value.getUTCFullYear() < 1970 ||
+          parsed_value.getUTCFullYear() > timeDateUtil.DateUpperBoundYear)
       ) {
         throw Error("Invalid date");
       }
@@ -2554,7 +2554,7 @@ class HIVTxNetwork {
   load_priority_sets(url, is_writeable) {
     this.fetch_priority_sets(url, (results) => {
       let latest_date = new Date();
-      latest_date.setFullYear(1900);
+      latest_date.setUTCFullYear(1900);
       this.defined_priority_groups = this.isMJCNetwork && results.clusters ? _.clone(results.clusters) : _.clone(results);
       _.each(this.defined_priority_groups, (pg) => {
         _.each(pg.nodes, (n) => {
@@ -3213,7 +3213,7 @@ class HIVTxNetwork {
           if (value) {
             if (relative) {
               value = (this.get_reference_date() - value) / 31536000000;
-            } else value = String(value.getFullYear());
+            } else value = String(value.getUTCFullYear());
           } else {
             value = kGlobals.missing.label;
           }

--- a/src/misc.js
+++ b/src/misc.js
@@ -326,7 +326,7 @@ function hiv_trace_export_table_to_text(
 
 function hivtrace_coi_timeseries(cluster, element, plot_width) {
   const margin = { top: 30, right: 60, bottom: 10, left: 120 };
-  const formatTime = d3.time.format("%Y-%m-%d");
+  const formatTime = d3.time.format.utc("%Y-%m-%d");
   let data = _.sortBy(
     _.map(cluster.node_info, (d) => [d[0], formatTime.parse(d[1])]),
     (d) => d[1]
@@ -342,7 +342,7 @@ function hivtrace_coi_timeseries(cluster, element, plot_width) {
   plot_width = plot_width || 1000;
 
   let x = d3.time
-    .scale()
+    .scale.utc()
     .domain(x_range)
     .rangeRound([margin.left, plot_width - margin.right]);
 
@@ -356,7 +356,7 @@ function hivtrace_coi_timeseries(cluster, element, plot_width) {
     .scale(x)
     .orient("top")
     .ticks(plot_width / 80)
-    .tickFormat(d3.time.format("%m/%y"));
+    .tickFormat(d3.time.format.utc("%m/%y"));
 
   element.selectAll("svg").remove();
 
@@ -462,7 +462,7 @@ function hivtrace_coi_timeseries(cluster, element, plot_width) {
       //console.log (highlight_nodes);
       let years_ago = _.map([1, 3], (ya) => {
         let some_years_ago = new Date(d[1]);
-        some_years_ago.setFullYear(d[1].getFullYear() - ya);
+        some_years_ago.setUTCFullYear(d[1].getUTCFullYear() - ya);
         if (some_years_ago < x_range[0]) some_years_ago = x_range[0];
         return some_years_ago;
       });
@@ -914,33 +914,33 @@ function hivtrace_plot_cluster_dynamics(
 
   if (!bin_by) {
     bin_by = function (date) {
-      var year = date.getFullYear(),
+      var year = date.getUTCFullYear(),
         nearest_quarter = new Date(),
         mid_point = new Date();
 
-      nearest_quarter.setDate(1);
-      nearest_quarter.setFullYear(year);
-      mid_point.setFullYear(year);
+      nearest_quarter.setUTCDate(1);
+      nearest_quarter.setUTCFullYear(year);
+      mid_point.setUTCFullYear(year);
 
-      var quarter = Math.floor(date.getMonth() / 3);
+      var quarter = Math.floor(date.getUTCMonth() / 3);
 
-      nearest_quarter.setMonth(quarter * 3);
-      nearest_quarter.setHours(0, 0, 0);
-      mid_point.setHours(0, 0, 0);
+      nearest_quarter.setUTCMonth(quarter * 3);
+      nearest_quarter.setUTCHours(0, 0, 0, 0);
+      mid_point.setUTCHours(0, 0, 0, 0);
 
-      nearest_quarter.setFullYear(year);
-      mid_point.setMonth(quarter * 3 + 1);
-      mid_point.setDate(15);
+      nearest_quarter.setUTCFullYear(year);
+      mid_point.setUTCMonth(quarter * 3 + 1);
+      mid_point.setUTCDate(15);
 
       return ["Q" + (quarter + 1) + " " + year, nearest_quarter, mid_point];
     };
 
-    min_diff = new Date(2018, 3, 0) - new Date(2018, 0, 0);
+    min_diff = new Date(Date.UTC(2018, 3, 0)) - new Date(Date.UTC(2018, 0, 0));
   }
 
   var x_tick_format = function (d) {
-    var year = d.getFullYear();
-    var quarter = Math.floor(d.getMonth() / 3) + 1;
+    var year = d.getUTCFullYear();
+    var quarter = Math.floor(d.getUTCMonth() / 3) + 1;
 
     return String(year) + "-Q" + quarter;
   };
@@ -964,7 +964,7 @@ function hivtrace_plot_cluster_dynamics(
 
     */
 
-  var x = d3.time.scale().range([0, width]);
+  var x = d3.time.scale.utc().range([0, width]);
 
   var y = y_scale ? y_scale : d3.scale.linear();
 
@@ -978,8 +978,8 @@ function hivtrace_plot_cluster_dynamics(
     .axis()
     .scale(x)
     .orient("bottom")
-    .ticks(d3.time.month, 3)
-    .tickFormat(d3.time.format("%m/%Y"));
+    .ticks(d3.time.month.utc, 3)
+    .tickFormat(d3.time.format.utc("%m/%Y"));
 
   if (x_tick_format) {
     xAxis.tickFormat(x_tick_format);

--- a/src/scatterplot.js
+++ b/src/scatterplot.js
@@ -15,7 +15,7 @@ var d3 = require("d3");
 
 function hivtrace_render_scatterplot(points, w, h, id, labels, dates) {
   var _defaultFloatFormat = d3.format(",.2r");
-  var _defaultDateViewFormatShort = d3.time.format("%B %Y");
+  var _defaultDateViewFormatShort = d3.time.format.utc("%B %Y");
 
   var margin = {
       top: 10,
@@ -26,11 +26,11 @@ function hivtrace_render_scatterplot(points, w, h, id, labels, dates) {
     width = w - margin.left - margin.right,
     height = h - margin.top - margin.bottom;
 
-  var x = (dates ? d3.time.scale() : d3.scale.linear())
+  var x = (dates ? d3.time.scale.utc() : d3.scale.linear())
     .domain(d3.extent(points, (p) => p.x))
     .range([0, width]);
 
-  var y = (dates ? d3.time.scale() : d3.scale.linear())
+  var y = (dates ? d3.time.scale.utc() : d3.scale.linear())
     .domain(d3.extent(points, (p) => p.y))
     .range([height, 0]);
 

--- a/src/tables.js
+++ b/src/tables.js
@@ -642,11 +642,11 @@ function filter_parse(filter_value) {
                 [is_range[1], is_range[2]],
                 (d) =>
                   new Date(
-                    d.substring(0, 4) +
-                      "-" +
-                      d.substring(4, 6) +
-                      "-" +
+                    Date.UTC(
+                      d.substring(0, 4),
+                      parseInt(d.substring(4, 6)) - 1,
                       d.substring(6, 8)
+                    )
                   )
               ),
             };

--- a/src/timeDateUtil.js
+++ b/src/timeDateUtil.js
@@ -11,30 +11,30 @@ const _networkTimeQuery = /([0-9]{8}):([0-9]{8})/i;
 
 const DateViewFormatExport = d3.time.format.utc("%m/%d/%Y");
 
-const DateViewFormatMMDDYYY = d3.time.format("%m%d%Y");
+const DateViewFormatMMDDYYY = d3.time.format.utc("%m%d%Y");
 /** this is currently used to display node addition dates to COI */
 
-const DateViewFormatShort = d3.time.format("%B %Y");
+const DateViewFormatShort = d3.time.format.utc("%B %Y");
 /** Used to generate legend labels for date-valued attributes for network displayes*/
 
-const DateViewFormat = d3.time.format("%b %d, %Y");
+const DateViewFormat = d3.time.format.utc("%b %d, %Y");
 /** Used to generate pop-over labels for node displays, and COI views*/
 
 /** SLKP 20241029; add another acceptable data time format */
 
-const DateFormats = [d3.time.format.iso, d3.time.format("%Y%m%d")];
+const DateFormats = [d3.time.format.iso, d3.time.format.utc("%Y%m%d")];
 /** List of accepted time formats for attribute values*/
 
-const DateViewFormatSlider = d3.time.format("%Y-%m-%d");
+const DateViewFormatSlider = d3.time.format.utc("%Y-%m-%d");
 /** Used in many places where alpha-numerically sorted dates are desired*/
 
-const DateViewNodeSearch = d3.time.format("%Y/%m/%d");
+const DateViewNodeSearch = d3.time.format.utc("%Y/%m/%d");
 /** Used in many places where alpha-numerically sorted dates are desired*/
 
-const DateUpperBoundYear = new Date().getFullYear();
+const DateUpperBoundYear = new Date().getUTCFullYear();
 /** Maximum year value (no future dates)*/
 
-const DateViewFormatClusterCreate = d3.time.format("%Y%m");
+const DateViewFormatClusterCreate = d3.time.format.utc("%Y%m");
 /** used as a part of auto-named COI, e.g. NC_202105_44.1 */
 
 let cluster_time_scale;
@@ -57,7 +57,7 @@ function getCurrentDate() {
 }
 
 function getAncientDate() {
-  return new Date(1900, 0, 1);
+  return new Date(Date.UTC(1900, 0, 1));
 }
 
 /**
@@ -92,19 +92,19 @@ function hivtrace_date_or_na_if_missing(date, formatter) {
 
 function n_months_ago(reference_date, months) {
   var past_date = new Date(reference_date);
-  var past_months = past_date.getMonth();
+  var past_months = past_date.getUTCMonth();
   var diff_year = Math.floor(months / 12);
   var left_over = months - diff_year * 12;
 
   if (left_over > past_months) {
-    past_date.setFullYear(past_date.getFullYear() - diff_year - 1);
-    past_date.setMonth(12 - (left_over - past_months));
+    past_date.setUTCFullYear(past_date.getUTCFullYear() - diff_year - 1);
+    past_date.setUTCMonth(12 - (left_over - past_months));
   } else {
-    past_date.setFullYear(past_date.getFullYear() - diff_year);
-    past_date.setMonth(past_months - left_over);
+    past_date.setUTCFullYear(past_date.getUTCFullYear() - diff_year);
+    past_date.setUTCMonth(past_months - left_over);
   }
-  past_date.setDate(past_date.getDate() + 1); // exclusive
-  past_date.setUTCHours(0, 0, 0);
+  past_date.setUTCDate(past_date.getUTCDate() + 1); // exclusive
+  past_date.setUTCHours(0, 0, 0, 0);
   return past_date;
 }
 


### PR DESCRIPTION
This commit addresses an issue where node attributes like 'hiv_aids_dx_dt' were displayed as one day BEFORE the date recorded in the JSON file. The root cause was the application's use of local-time d3 formatters and Date methods to render UTC-stored timestamps, which caused a backwards shift for users in Western timezones.

Changes:
- Migrated all date formatters in `timeDateUtil.js` to `d3.time.format.utc`.
- Replaced local Date methods (`.getFullYear, .setMonth`, etc.) with UTC equivalents (`.getUTCFullYear, .setUTCMonth`, etc.) across the frontend logic (src/hiv_tx_network.js, src/clusternetwork.js, src/misc.js).
- Updated time scales in visualizations (scatterplot.js, misc.js) to use `d3.time.scale.utc()`.
- Fixed table filter parsing in tables.js to use `Date.UTC` for range queries.

Resolves: https://github.com/veg/hivtrace-secure/issues/454