### PR TITLE
fix: overlap button overflow in clusterOI table

### DIFF
--- a/src/clustersOfInterest.js
+++ b/src/clustersOfInterest.js
@@ -1831,7 +1831,7 @@ function draw_priority_set_table(
               : [
                   {
                     icon: "fa-eye",
-                    dropdown_align: "right",
+                    force_line_break: true,
                     dropdown: [
                       {
                         label: "List overlaps",
@@ -1906,7 +1906,7 @@ function draw_priority_set_table(
               : [
                   {
                     icon: "fa-eye",
-                    dropdown_align: "right",
+                    force_line_break: true,
                     dropdown: [
                       {
                         label: "List overlaps",

--- a/src/clustersOfInterest.js
+++ b/src/clustersOfInterest.js
@@ -1831,6 +1831,7 @@ function draw_priority_set_table(
               : [
                   {
                     icon: "fa-eye",
+                    dropdown_align: "right",
                     dropdown: [
                       {
                         label: "List overlaps",
@@ -1905,6 +1906,7 @@ function draw_priority_set_table(
               : [
                   {
                     icon: "fa-eye",
+                    dropdown_align: "right",
                     dropdown: [
                       {
                         label: "List overlaps",

--- a/src/tables.js
+++ b/src/tables.js
@@ -387,7 +387,8 @@ function format_a_cell(data, index, item, priority_set_editor) {
 
               var dropdown_list = button_group_dropdown
                 .append("ul")
-                .classed("dropdown-menu", true);
+                .classed("dropdown-menu", true)
+                .classed("dropdown-menu-right", b.dropdown_align === "right");
               //.attr("aria-labelledby", menu_id);
 
               let items = b.dropdown;

--- a/src/tables.js
+++ b/src/tables.js
@@ -385,10 +385,13 @@ function format_a_cell(data, index, item, priority_set_editor) {
                 .classed("btn btn-default btn-xs dropdown-toggle", true)
                 .attr("data-toggle", "dropdown");
 
+              if (b.force_line_break) {
+                button_group.attr("style", "display: block;");
+              }
+
               var dropdown_list = button_group_dropdown
                 .append("ul")
-                .classed("dropdown-menu", true)
-                .classed("dropdown-menu-right", b.dropdown_align === "right");
+                .classed("dropdown-menu", true);
               //.attr("aria-labelledby", menu_id);
 
               let items = b.dropdown;


### PR DESCRIPTION
For site view, when you click the eye button in the "MJ ClusterOI Overlap Count" column, the "List overlaps" button gets cropped out. This fixes it by making sure that the eye button is always on the far left, so the "list overlaps" button will always have enough space.