### PR TITLE
fix: MJC page, dates, cluster table, cluster export, node export

### DIFF
--- a/src/clusternetwork.js
+++ b/src/clusternetwork.js
@@ -2314,7 +2314,8 @@ var hivtrace_cluster_network_graph = function (
           alert(kGlobals.network.WarnExecutiveMode);
         } else {
           helpers.export_csv_button(
-            self._extract_attributes_for_nodes(cluster_nodes, column_ids)
+            self._extract_attributes_for_nodes(cluster_nodes, column_ids),
+            self.isMJCNetwork ? "MJ_export" : undefined
           );
         }
       });

--- a/src/clustersOfInterest.js
+++ b/src/clustersOfInterest.js
@@ -1387,7 +1387,7 @@ function _action_drop_down(self, pg) {
               site_pg_name,
               copied_node_objects,
               "A copy of " + pg.name + " that contains site sequences only.",
-              "02 national molecular cluster analysis",
+              "01 state/local molecular cluster analysis",
               pg.tracking
             );
           }
@@ -2138,13 +2138,15 @@ function draw_priority_set_table(
     ).on("click", (d) => {
       helpers.export_csv_button(
         self.priority_groups_export_nodes(),
-        "clusters-of-interest"
+        self.isMJCNetwork ? "MJ_clusters-of-interest" : "clusters-of-interest"
       );
     });
     d3.select("#priority_set_table_download").on("click", (d) => {
       helpers.export_csv_button(
         self.priority_groups_export_sets(),
-        "clusters_of_interest_table"
+        self.isMJCNetwork
+          ? "MJ_clusters_of_interest_table"
+          : "clusters_of_interest_table"
       );
     });
 

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -1789,7 +1789,7 @@ class HIVTxNetwork {
 
           if (this.isMJCNetwork && g.cluster_detect_size != null) {
             // The client-side count below undercounts once other jurisdictions'
-            // `added` dates are redacted; use the backend's all-sites value (#14).
+            // `added` dates are redacted; use the backend's all-sites value.
             cluster_detect_size = g.cluster_detect_size;
           } else {
             cluster_detect_size = this.unique_entity_list_from_ids(
@@ -1802,9 +1802,9 @@ class HIVTxNetwork {
             ).length;
           }
 
-          // #21 MJ_and_site_clusterOI_overlap: overlap between MJ and site
-          // clusterOI. In the MJC view that's `g.overlap`; in the site view the
-          // MJ overlap lives in `g.overlap_mjc` (`g.overlap` is site-to-site).
+          // Overlap between MJ and site clusterOI. In the MJC view that's
+          // `g.overlap`; in the site view the MJ overlap lives in
+          // `g.overlap_mjc` (there `g.overlap` is site-to-site).
           const mj_site_overlap =
             (this.isMJCNetwork ? g.overlap : g.overlap_mjc) || {};
 
@@ -1829,7 +1829,7 @@ class HIVTxNetwork {
             (gn) => {
               const eid = this.entity_id(gn);
               const rep = (entity_to_g_records[eid] || [])[0];
-              // #5: per-person MJC attributes (join arrays e.g. joint_owners).
+              // Per-person MJC attributes (join arrays e.g. joint_owners).
               const mjc_attr = (key) => {
                 const v = this.attribute_node_value_by_id(
                   rep,
@@ -1883,9 +1883,9 @@ class HIVTxNetwork {
                 SequenceID: this.list_of_aliased_sequences(gn)
                   .map((seq) => this.cleanRedacted(seq.split("|")[1]))
                   .join(";"),
-                // #5: individual-level MJC variables (concept doc). MJC only —
-                // these attributes don't exist on regular site networks. Values
-                // arrive pre-redacted from the backend per the MJC-variables config.
+                // Individual-level MJC variables. MJC only — these attributes
+                // don't exist on regular site networks; values arrive
+                // pre-redacted from the backend per the sharing config.
                 ...(this.isMJCNetwork
                   ? {
                       jurisdiction: mjc_attr("jurisdiction"),
@@ -1931,7 +1931,7 @@ class HIVTxNetwork {
       _.map(
         _.filter(this.defined_priority_groups, (g) => g.validated),
         (g) => {
-          // See priority_groups_export_nodes for the MJ_and_site overlap source. (#21)
+          // MJ↔site overlap: g.overlap in the MJC view, g.overlap_mjc otherwise.
           const mj_site_overlap =
             (this.isMJCNetwork ? g.overlap : g.overlap_mjc) || {};
           return {
@@ -2143,7 +2143,7 @@ class HIVTxNetwork {
 
       _.each(groups, (pg) => {
         // All MJ clusterOI are S-TRACE state/local analyses tracked at "3 years,
-        // 0.5% distance" (#8, #16/#18); normalize unless the backend redacted it.
+        // 0.5% distance"; normalize unless the backend redacted these fields.
         if (this.isMJCNetwork) {
           if (pg.kind !== "REDACTED") {
             pg.kind = kGlobals.CDCCOIKind[0];
@@ -2152,7 +2152,7 @@ class HIVTxNetwork {
             pg.tracking = kGlobals.CDCCOITrackingOptions[0];
           }
           // person_ident_method is the node `kind`; all MJ members are
-          // S-TRACE auto-identified → "01 through analysis/notification" (#9).
+          // S-TRACE auto-identified → "01 through analysis/notification".
           _.each(pg.nodes, (n) => {
             if (n.kind !== "REDACTED") {
               n.kind = kGlobals.CDCCOINodeKindDefault;
@@ -4213,8 +4213,7 @@ class HIVTxNetwork {
   /**
    * A node's `mjc_date_identified[_12mo]` value for one cluster. These maps are
    * keyed by cluster name; pull the entry for `cluster_name`. `format_date`
-   * formats the value as a date. Mirrors the injection in
-   * clusternetwork._extract_mjc_attributes for use outside the node-list view. (#5)
+   * formats the value as a date.
    */
   mjc_selected_for_cluster(node, attr_key, cluster_name, format_date) {
     const attrs = node && node[kGlobals.network.NodeAttributeID];

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -1828,6 +1828,18 @@ class HIVTxNetwork {
             }),
             (gn) => {
               const eid = this.entity_id(gn);
+              const rep = (entity_to_g_records[eid] || [])[0];
+              // #5: per-person MJC attributes (join arrays e.g. joint_owners).
+              const mjc_attr = (key) => {
+                const v = this.attribute_node_value_by_id(
+                  rep,
+                  key,
+                  false,
+                  false,
+                  true
+                );
+                return Array.isArray(v) ? v.join("; ") : v;
+              };
               return {
                 eHARS_uid: this.cleanRedacted(eid),
                 cluster_uid: this.cleanRedacted(g.name),
@@ -1871,6 +1883,36 @@ class HIVTxNetwork {
                 SequenceID: this.list_of_aliased_sequences(gn)
                   .map((seq) => this.cleanRedacted(seq.split("|")[1]))
                   .join(";"),
+                // #5: individual-level MJC variables (concept doc). MJC only —
+                // these attributes don't exist on regular site networks. Values
+                // arrive pre-redacted from the backend per the MJC-variables config.
+                ...(this.isMJCNetwork
+                  ? {
+                      jurisdiction: mjc_attr("jurisdiction"),
+                      joint_owners: mjc_attr("joint_owners"),
+                      cur_state_cd: mjc_attr("cur_state_cd"),
+                      rsd_state_cd: mjc_attr("rsd_state_cd"),
+                      selected_mjc_date_identified:
+                        this.mjc_selected_for_cluster(
+                          rep,
+                          "mjc_date_identified",
+                          g.name,
+                          true
+                        ),
+                      selected_mjc_date_identified_12mo:
+                        this.mjc_selected_for_cluster(
+                          rep,
+                          "mjc_date_identified_12mo",
+                          g.name,
+                          false
+                        ),
+                      hiv_aids_dx_dt_month_year: mjc_attr(
+                        "hiv_aids_dx_dt_month_year"
+                      ),
+                      hiv_aids_dx_dt_12mo: mjc_attr("hiv_aids_dx_dt_12mo"),
+                      hiv_aids_dx_dt_36mo: mjc_attr("hiv_aids_dx_dt_36mo"),
+                    }
+                  : {}),
               };
             }
           );
@@ -4166,6 +4208,23 @@ class HIVTxNetwork {
       return "REDACTED";
     }
     return id;
+  }
+
+  /**
+   * A node's `mjc_date_identified[_12mo]` value for one cluster. These maps are
+   * keyed by cluster name; pull the entry for `cluster_name`. `format_date`
+   * formats the value as a date. Mirrors the injection in
+   * clusternetwork._extract_mjc_attributes for use outside the node-list view. (#5)
+   */
+  mjc_selected_for_cluster(node, attr_key, cluster_name, format_date) {
+    const attrs = node && node[kGlobals.network.NodeAttributeID];
+    if (!attrs || !(attr_key in attrs)) return kGlobals.missing.label;
+    const v = attrs[attr_key];
+    if (typeof v !== "object" || v === null) return v; // scalar or "REDACTED"
+    if (!Object.hasOwn(v, cluster_name)) return kGlobals.missing.label;
+    return format_date
+      ? timeDateUtil.DateViewFormatExport(this.parse_dates(new Date(v[cluster_name])))
+      : v[cluster_name];
   }
 
   /**

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -2591,6 +2591,7 @@ class HIVTxNetwork {
 
           if (
             auto_extend &&
+            !this.isMJCNetwork &&
             pg.tracking !== kGlobals.CDCCOITrackingOptionsNone
           ) {
             const added_nodes = this.auto_expand_pg_handler(

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -1270,6 +1270,7 @@ class HIVTxNetwork {
         nodes: overlap.nodes,
         // sets = number of distinct overlap_groups that share nodes with this mjc_group
         sets: overlap.sets.size,
+        set_names: Array.from(overlap.sets),
         superset: overlap.supersets,
         duplicate: overlap.duplicates,
       };
@@ -1786,14 +1787,26 @@ class HIVTxNetwork {
 
           let entities = this.aggregate_indvidual_level_records(g.node_objects);
 
-          cluster_detect_size = this.unique_entity_list_from_ids(
-            _.map(
-              _.filter(g.nodes, (node) => {
-                return node.added <= g.created;
-              }),
-              (node) => node.name
-            )
-          ).length;
+          if (this.isMJCNetwork && g.cluster_detect_size != null) {
+            // The client-side count below undercounts once other jurisdictions'
+            // `added` dates are redacted; use the backend's all-sites value (#14).
+            cluster_detect_size = g.cluster_detect_size;
+          } else {
+            cluster_detect_size = this.unique_entity_list_from_ids(
+              _.map(
+                _.filter(g.nodes, (node) => {
+                  return node.added <= g.created;
+                }),
+                (node) => node.name
+              )
+            ).length;
+          }
+
+          // #21 MJ_and_site_clusterOI_overlap: overlap between MJ and site
+          // clusterOI. In the MJC view that's `g.overlap`; in the site view the
+          // MJ overlap lives in `g.overlap_mjc` (`g.overlap` is site-to-site).
+          const mj_site_overlap =
+            (this.isMJCNetwork ? g.overlap : g.overlap_mjc) || {};
 
           const entity_to_pg_records = _.groupBy(
             _.filter(g.nodes, (nr) => !exclude_nodes.has(nr.name)),
@@ -1848,11 +1861,15 @@ class HIVTxNetwork {
                 national_priority: g.meets_priority_def,
                 cluster_current_size: entities.length,
                 cluster_dx_recent12_mo: g.cluster_dx_recent12_mo,
-                cluster_overlap: g.overlap.sets,
+                ...(this.isMJCNetwork
+                  ? {}
+                  : { cluster_overlap: (g.overlap || {}).sets }),
+                MJ_and_site_clusterOI_overlap: (
+                  mj_site_overlap.set_names || []
+                ).join(";"),
+                MJ_and_site_clusterOI_overlap_count: mj_site_overlap.sets || 0,
                 SequenceID: this.list_of_aliased_sequences(gn)
-                  .map((seq) => {
-                    return seq.split("|")[1];
-                  })
+                  .map((seq) => this.cleanRedacted(seq.split("|")[1]))
                   .join(";"),
               };
             }
@@ -1871,25 +1888,36 @@ class HIVTxNetwork {
     return _.flatten(
       _.map(
         _.filter(this.defined_priority_groups, (g) => g.validated),
-        (g) => ({
-          cluster_type: g.createdBy,
-          cluster_uid: this.cleanRedacted(g.name),
-          cluster_modified_dt: timeDateUtil.hivtrace_date_or_na_if_missing(
-            g.modified
-          ),
-          cluster_created_dt: timeDateUtil.hivtrace_date_or_na_if_missing(
-            g.created
-          ),
-          cluster_ident_method: g.kind,
-          cluster_growth: kGlobals.CDCCOIConciseTrackingOptions[g.tracking],
-          cluster_current_size: this.aggregate_indvidual_level_records(
-            g.node_objects
-          ).length,
-          national_priority: g.meets_priority_def,
-          cluster_dx_recent12_mo: g.cluster_dx_recent12_mo,
-          cluster_dx_recent36_mo: g.cluster_dx_recent36_mo,
-          cluster_overlap: g.overlap.sets,
-        })
+        (g) => {
+          // See priority_groups_export_nodes for the MJ_and_site overlap source. (#21)
+          const mj_site_overlap =
+            (this.isMJCNetwork ? g.overlap : g.overlap_mjc) || {};
+          return {
+            cluster_type: g.createdBy,
+            cluster_uid: this.cleanRedacted(g.name),
+            cluster_modified_dt: timeDateUtil.hivtrace_date_or_na_if_missing(
+              g.modified
+            ),
+            cluster_created_dt: timeDateUtil.hivtrace_date_or_na_if_missing(
+              g.created
+            ),
+            cluster_ident_method: g.kind,
+            cluster_growth: kGlobals.CDCCOIConciseTrackingOptions[g.tracking],
+            cluster_current_size: this.aggregate_indvidual_level_records(
+              g.node_objects
+            ).length,
+            national_priority: g.meets_priority_def,
+            cluster_dx_recent12_mo: g.cluster_dx_recent12_mo,
+            cluster_dx_recent36_mo: g.cluster_dx_recent36_mo,
+            ...(this.isMJCNetwork
+              ? {}
+              : { cluster_overlap: (g.overlap || {}).sets }),
+            MJ_and_site_clusterOI_overlap: (
+              mj_site_overlap.set_names || []
+            ).join(";"),
+            MJ_and_site_clusterOI_overlap_count: mj_site_overlap.sets || 0,
+          };
+        }
       )
     );
   };
@@ -2072,6 +2100,23 @@ class HIVTxNetwork {
       let traversal_cache = null;
 
       _.each(groups, (pg) => {
+        // All MJ clusterOI are S-TRACE state/local analyses tracked at "3 years,
+        // 0.5% distance" (#8, #16/#18); normalize unless the backend redacted it.
+        if (this.isMJCNetwork) {
+          if (pg.kind !== "REDACTED") {
+            pg.kind = kGlobals.CDCCOIKind[0];
+          }
+          if (pg.tracking !== "REDACTED") {
+            pg.tracking = kGlobals.CDCCOITrackingOptions[0];
+          }
+          // person_ident_method is the node `kind`; all MJ members are
+          // S-TRACE auto-identified → "01 through analysis/notification" (#9).
+          _.each(pg.nodes, (n) => {
+            if (n.kind !== "REDACTED") {
+              n.kind = kGlobals.CDCCOINodeKindDefault;
+            }
+          });
+        }
         if (!pg.validated) {
           pg.node_objects = [];
           pg.not_in_network = [];
@@ -4117,7 +4162,7 @@ class HIVTxNetwork {
   }
 
   cleanRedacted(id) {
-    if (id.startsWith("REDACTED_")) {
+    if (typeof id === "string" && id.startsWith("REDACTED_")) {
       return "REDACTED";
     }
     return id;


### PR DESCRIPTION
To be merged after #214, with the merge of https://github.com/veg/hivtrace-secure/pull/523

Addresses the MJ testing findings (`MJ_testing_findings_exports_v2026-06-04`). Each row below is keyed to its finding number. The work spans `hivtrace-secure`, `hivtrace-viz`, and `hivtrace-secure-server` (the compute backend).

**(WIP) These changes have not yet been tested on staging.**

## Findings index

| # | Disposition | Where |
|---|-------------|-------|
| 1 | Fixed | Export filenames |
| 2 | Fixed | MJ page header (dates) |
| 3 | Dropped (won't do) | Design note |
| 4 | Fixed | MJ page header (dates) |
| 5 | Fixed | Node-level export columns |
| 6 | Skipped (scope creep) | Out of scope |
| 7 | Fixed | MJ cluster fields — name, identification method, growth |
| 8 | Fixed | MJ cluster fields — name, identification method, growth |
| 9 | Fixed | MJ cluster fields — name, identification method, growth |
| 10 | No fix needed (wall-clock) | Design note |
| 11 | Deferred → `hivtrace-secure-server` | Remaining work |
| 12 | Resolved via `#15` | Design note |
| 13 | No fix needed (wall-clock) | Design note |
| 14 | Fixed | MJ cluster dates, sizes, and counts |
| 15 | Fixed | MJ cluster dates, sizes, and counts |
| 16 | Fixed | MJ cluster fields — name, identification method, growth |
| 17 | Fixed | Node-level export columns |
| 18 | Fixed | MJ cluster fields — name, identification method, growth |
| 19 | Resolved via `#15` | Design note |
| 20 | Fixed | MJ cluster dates, sizes, and counts |
| 21 | Fixed | Node-level export columns |
| 22 | Skipped (scope creep) | Out of scope |
| A1 | Fixed | Additional fixes |

---

## Export filenames

| # | Change | Where |
|---|--------|-------|
| 1 | When viewing an MJ network, all three exports download with an `MJ_` prefix: `MJ_export.csv` (listing nodes), `MJ_clusters-of-interest.csv` (Export to CSV), and `MJ_clusters_of_interest_table.csv` (table download). Regular site exports keep their original names. | `hivtrace-viz`: `clustersOfInterest.js`, `clusternetwork.js` |


## MJ page header (dates)

Shown on the MJ network view, mirroring the regular site page.

| # | Change | Where |
|---|--------|-------|
| 2 | The "Created" label on the MJ page is renamed to "MJ created". | `hivtrace-secure`: `network_view.ejs` |
| 4 | Added a "Last date my data included" line — the viewing jurisdiction's own eHARS reference date (the date of its most-recent source-network/upload that fed this MJ network). Hidden for users who are not participants. | `hivtrace-secure`: `mjc_results.js` (`lastIncludedDate`), `mjc_network.js`, `network_view.ejs` |

## MJ cluster fields — name, identification method, growth

These normalize cluster/node fields that arrive from the backend with placeholder values, while preserving any `REDACTED` masking applied for non-owning jurisdictions.

| # | Change | Where |
|---|--------|-------|
| 7 | MJ cluster name / `cluster_uid` is now `MJ_YYYY_MM_[clusterID]` (year/month from the run reference date) instead of `MJC-YYYY-[clusterID]`. The detector builds the name and the identification-date index together, so the join stays consistent; the web app's cluster-name parser accepts the new format (and still the legacy one). | `hivtrace-secure-server`: `mjc-clusteroi-detector.js`; `hivtrace-secure`: `lib/mjc-clusteroi-detector.js`, `mjc.js` |
| 8 | `cluster_ident_method` is now "01 state/local molecular cluster analysis" for all MJ clusterOI (UI table and both CSV exports). Creating a site clusterOI from an MJ clusterOI also uses "01 state/local…" instead of "02 national…" (which is reserved for CDC analyses). | `hivtrace-viz`: `hiv_tx_network.js` (normalizes `pg.kind` in `priority_groups_validate`), `clustersOfInterest.js` (copy uses the new value) |
| 9 | `person_ident_method` is now "01 through analysis/notification" for all MJ cluster members (they are all S-TRACE auto-identified). Previously the export showed the backend placeholder `auto-mj-clusteroi`. | `hivtrace-viz`: `hiv_tx_network.js` (normalizes each node's `kind`) |
| 16 / 18 | `cluster_growth` now populates as "3 years, 0.5% distance" in the node CSV, the table CSV, and the UI Growth column, and carries over to a site clusterOI copied from an MJ clusterOI. Previously blank. | `hivtrace-viz`: `hiv_tx_network.js` (normalizes `pg.tracking`) |

## MJ cluster dates, sizes, and counts

| # | Change | Where |
|---|--------|-------|
| 14 | `cluster_detect_size` now reflects the cluster's size at first detection across all involved jurisdictions. It is captured once when the cluster is created (a new `detect_size` field on the model) and served pre-redaction, so members owned by other jurisdictions are not dropped. Previously it under-counted to only the viewing jurisdiction. | `hivtrace-secure`: `mjc_clusteroi.js`, `priority_set.js`; `hivtrace-viz`: `hiv_tx_network.js` |
| 15 | `cluster_modified_dt` now bumps only when the cluster actually changes (members added, or it drops out of priority) instead of on every analysis run. The value stays wall-clock (run time), by design. | `hivtrace-secure`: `mjc_clusteroi.js` (`persistAndMerge`, `last_updated`) |
| 20 | `cluster_dx_recent36_mo` now populates in the table CSV (previously blank). The value was already computed and persisted on the backend but was not being serialized to the response. It is gated for non-owners by a new dedicated `mjcDiagnosesLast36MonthsEnabled` sharing flag (its own admin toggle), parallel to the existing 12-month flag. | `hivtrace-secure`: `priority_set.js`, `mjc-redact.js`, `cluster_data_sharing_config.js`, `mjc_dashboard.ejs`; `hivtrace-viz` already read it |

## Node-level export columns

Columns in the `MJ_clusters-of-interest` node export.

| # | Change | Where |
|---|--------|-------|
| 5 | Added nine individual-level columns to the node export (MJ networks only): `jurisdiction`, `joint_owners`, `cur_state_cd` (state of current residence), `rsd_state_cd` (state of residence at diagnosis), `selected_mjc_date_identified` (date identified as part of the MJ clusterOI), `selected_mjc_date_identified_12mo` (identified in the last 12 months), `hiv_aids_dx_dt_month_year` (diagnosis month/year), `hiv_aids_dx_dt_12mo` (diagnosed in the last 12 months), `hiv_aids_dx_dt_36mo` (diagnosed in the last 36 months). Values arrive pre-redacted from the backend per the MJC-variables sharing config. | `hivtrace-viz`: `hiv_tx_network.js` |
| 17 | `SequenceID` now shows the literal `REDACTED` for rows the viewing jurisdiction does not own. The underlying value was already hashed by the backend; this presents it cleanly, matching how `eHARS_uid` is shown. | `hivtrace-viz`: `hiv_tx_network.js` |
| 21 | Renamed `cluster_overlap` to `MJ_and_site_clusterOI_overlap` (a semicolon-separated list of the overlapping clusterOI names) and added a separate `MJ_and_site_clusterOI_overlap_count` (integer). This MJ-and-site overlap is now also included in the site clusterOI export. | `hivtrace-viz`: `hiv_tx_network.js` |

## Additional fixes (outside the numbered findings)

| Change | Where |
|--------|-------|
| The "Back to MJC Networks" button (which links to an admin-only page) no longer appears on redacted / site views; those now show "Back to Home" instead. Previously it could link a redacted view to a page it shouldn't reach. | `hivtrace-secure`: `network_view.ejs` |

---

## Out of scope (intentionally skipped)

| # | Reason |
|---|--------|
| 6 | New `*_in_my_jur` node variables (`Priority_in_my_jur`, `new_linked_case_in_my_jur`, `cluster_detect_size_in_my_jur`, `cluster_current_size_in_my_jur`, `cluster_dx_recent12_mo_in_my_jur`, `cluster_dx_recent36_mo_in_my_jur`). Not present in the spec/concept document (v2026-02-09); confirmed as scope creep on a call with Steven and Joel on 6/5. |
| 22 | The same `*_in_my_jur` cluster-level variables for the table CSV. Same reason as `#6`. |

## Design note: MJ dates are wall-clock (run date)

MJ cluster dates and the diagnosis-recency windows are intentionally anchored to the **wall-clock run date**, not the upload eHARS reference date. So `cluster_created_dt`, `cluster_modified_dt`, `network_date`, `person_ident_dt`, `selected_mjc_date_identified`, and the 12/36-month counts (`cluster_dx_recent12_mo`/`36_mo`, `hiv_aids_dx_dt_12mo`/`36mo`) all reflect when the analysis ran. This PR does not change that anchoring; `person_ident_dt` being wall-clock already satisfies `#10`'s date. (An earlier iteration of this branch moved several of these to the eHARS reference date — those changes were reverted.)

The one intentional exception is `#4` "Last date my data included," which is the viewing jurisdiction's *own* upload (eHARS reference) date — a per-site data date, not a run date.

Disposition of the related findings under this direction:
- **`#3`** (an "MJ eHARS reference date" line): dropped — there is no MJ eHARS reference date.
- **`#13`** `network_date`, **`#10`** `person_ident_dt`: no fix needed — both are wall-clock, which is the expected value.
- **`#12` / `#19`** (created/modified): the values stay wall-clock, and the reported "modified == created despite network changes" is fixed by `#15` — `modified` now advances only when the cluster actually changes, so it diverges from `created`.

## Remaining work (not in this PR)

| # | What remains | Notes |
|---|---|---|
| 11 | `sample_dt` not populating; plus selecting the earliest clustering sequence (`veg/hivtrace-secure#370`). | In the MJ compute backend (`hivtrace-secure-server`); cross-cutting with single-site clusterOI. |
