### PR TITLE
fix(mjc): make load overlay work and clear for direct-constructor boots

### DIFF
--- a/src/clusternetwork.js
+++ b/src/clusternetwork.js
@@ -7847,6 +7847,17 @@ var hivtrace_cluster_network_graph = function (
       d3.select(self.container)
         .selectAll(".my_progress")
         .style("display", "none");
+      // The redacted MJC view renders no network/tables and returns early, so
+      // nothing downstream would clear the generic loading overlay. Tear it
+      // down here so the page does not hang on "Analyzing Network Data".
+      if (typeof window !== "undefined") {
+        if (window.perfMeasurements) {
+          window.perfMeasurements.done = true;
+        }
+        if (window.finalizeNetworkLoading) {
+          window.finalizeNetworkLoading();
+        }
+      }
       return;
     }
 
@@ -7968,6 +7979,17 @@ var hivtrace_cluster_network_graph = function (
             .style("display", "none");
           self.network_svg.selectAll(".svg-loading-placeholder").remove();
           self.draw_attribute_labels();
+          // Network render + layout are complete. Tear down the generic loading
+          // overlay (installed by initializeLoadingScreen) for pages that boot
+          // without the window.init interceptor, e.g. the secure app.
+          if (typeof window !== "undefined") {
+            if (window.perfMeasurements) {
+              window.perfMeasurements.done = true;
+            }
+            if (window.finalizeNetworkLoading) {
+              window.finalizeNetworkLoading();
+            }
+          }
           return;
         }
         setTimeout(() => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -730,6 +730,17 @@ function initializeLoadingScreen() {
     return;
   }
 
+  // Mark that an initial network load is in progress. Normally the window.init
+  // interceptor creates this, but pages that boot by constructing the cluster
+  // network directly (e.g. the secure app's results/MJC views) never assign a
+  // global `init`. Setting it here lets those pages participate in the loading
+  // UI: the render pipeline shows progress while building and clears the
+  // overlay via finalizeNetworkLoading() when it completes (see clusternetwork
+  // runSteps completion and the redacted-MJC early return).
+  if (typeof window !== "undefined") {
+    window.perfMeasurements = window.perfMeasurements || { done: false };
+  }
+
   // Hide the progress bar immediately on load
   d3.selectAll(".my_progress").style("display", "none");
 


### PR DESCRIPTION
## Problem

The admin MJC network view (`/admin/mjc-networks/...`) hangs on load showing **"Analyzing Network Data / Starting layout simulation…"** — the network finishes building but the content never becomes visible (*"it's just not a container being updated to view"*).

## Root cause

The chunked-render loading overlay was wired to clear **only through the `window.init` interceptor**, which is what creates `window.perfMeasurements`:

1. The MJC/results templates **server-render `#network_tag`**, so on `DOMContentLoaded` the viz's `initializeLoadingScreen()` installs an **"Analyzing Network Data" `.loading-placeholder`** over every `.tab-pane` and hides their children.
2. That overlay is only torn down by `finalizeNetworkLoading()`, which fires exclusively from the `window.init` wrapper.
3. The secure app boots by constructing `hivtrace.clusterNetwork` **directly** (`results.js`, `results_mjc.js`) and never assigns a global `init`. So `perfMeasurements` is never created, `finalizeNetworkLoading()` is never called, and the overlay never clears — even though the network finished building underneath.

## Fix

Make the loading feature **work** for direct-constructor consumers instead of disabling it, so the secure app gets the loading UI too:

- **`initializeLoadingScreen()`** — create `window.perfMeasurements` when the overlay is installed, so any page with `#network_tag` is recognized as an initial load (not just `window.init` pages).
- **`runSteps` completion** — tear down the overlay (`finalizeNetworkLoading()`) at the authoritative render + layout-done point.
- **Redacted MJC early-return** — that path renders nothing, so clear the overlay explicitly to avoid a hang.

The `window.init` demo path is unchanged: the calls are idempotent and now fire after layout settles rather than immediately after the synchronous constructor returns.

## Testing

- `webpack` build succeeds; diff is limited to the three intended hunks.
- Verified the rebuilt bundle, dropped into the secure app, shows the loading UI **and clears it** on the admin MJC view at `/admin/mjc-networks/california/<uuid>`.

## Consumer impact

`hivtrace-secure` picks this up purely by bumping its `hivtrace-viz-legacy` dependency to the published beta containing this fix — no secure-side code change required.
