### PR TITLE
fix(coi): raise clusterOI name length cap 35 -> 40 chars

### DIFF
--- a/src/clustersOfInterest.js
+++ b/src/clustersOfInterest.js
@@ -78,7 +78,7 @@ function init(self) {
 
  * @description
  * A valid name must:
- *  - Have a length between 1 and 35 characters.
+ *  - Have a length between 1 and 40 characters.
  *  - Not be a duplicate among existing priority groups (excluding itself if editing).
  */
 
@@ -88,7 +88,7 @@ function priority_groups_check_name(
   prior_name
 ) {
   if (string.length) {
-    if (string.length >= 36) return false;
+    if (string.length >= 41) return false;
     return !_.some(
       defined_priority_groups,
       (d) => d.name === string && d.name !== prior_name
@@ -564,13 +564,13 @@ function open_editor(
             save_set_button.attr("disabled", null);
           }
         } else {
-          let too_long = current_text.length >= 36;
+          let too_long = current_text.length >= 41;
           grp_name.classed({
             "has-success": false,
             "has-error": true,
           });
           let error_message = too_long
-            ? "MUST be shorter than 36 characters"
+            ? "MUST be 40 characters or fewer"
             : "MUST be unique";
           grp_name_box_label.text(
             "Name this cluster of interest " + error_message


### PR DESCRIPTION
MJ cluster names (`MJ_YYYY_MM_<id>`, up to ~26 chars) overran the 35-char clusterOI name limit once prefixed with SITE_COPY_ (10 chars) when a site copies an MJ clusterOI, producing a truncated/mangled name. The 35-char cap was a viz-only UI rule (no enforcement in hivtrace-secure's cluster_uid String field, the server SAS/CSV exporters, or patient_attribute_schema). Raise it to 40 so a SITE_COPY_ of a full-length MJ name (36 chars) fits with headroom.