### PR TITLE
fix(mjc): correct node matching and surface counts when creating a site ClusterOI from an MJC

### DIFF
--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -1694,7 +1694,36 @@ class HIVTxNetwork {
         return response.json();
       })
       .then((data) => {
-        alert("ClusterOI '" + name + "' added successfully from MJC.");
+        const summary = (data && data.summary) || null;
+        if (summary && typeof summary.added === "number") {
+          const requested =
+            summary.requested != null ? summary.requested : summary.added;
+          let msg =
+            "ClusterOI '" +
+            name +
+            "' created: " +
+            summary.added +
+            " of " +
+            requested +
+            " people added";
+          if (summary.nodes_added != null) {
+            msg += " (" + summary.nodes_added + " nodes)";
+          }
+          msg += ".";
+          if (summary.not_found) {
+            msg +=
+              "\n" +
+              summary.not_found +
+              " person(s) in the MJC clusterOI were not found in your jurisdiction's network and were not added.";
+          }
+          if (summary.added === 0) {
+            msg +=
+              "\nNote: none of the MJC clusterOI's people are in your jurisdiction's network, so this ClusterOI is empty.";
+          }
+          alert(msg);
+        } else {
+          alert("ClusterOI '" + name + "' added successfully from MJC.");
+        }
       })
       .catch((error) => {
         console.error("Error adding ClusterOI from MJC:", error);


### PR DESCRIPTION
To be merged with https://github.com/veg/hivtrace-secure/pull/526

Creating a site Cluster of Interest from an MJC (multijurisdictional cluster) network only keeps nodes that exist in the site's own network. Two problems with the old behavior:

1. **Wrong match key.** Nodes were matched by exact full id (`ehars_uid|document_uid|lab_seq|seq_length`). The trailing segments are sequence/run-specific, so the *same person* can have a different full id in the MJC run vs. the site's stored network — silently dropping a site's **own** people, not just cross-jurisdiction ones.
2. **Silent loss.** No count or message was returned: the user had no way to know nodes were dropped, or whether the loss was expected (other jurisdictions) or a stale/partial site network.

This change matches on the person key (ehars_uid), stores the site network's own node ids for matched people, and returns a per-person summary so the UI can report what happened.

## Changes

Backend (hivtrace-secure):
- `app/models/priority_set.js` — `handleAddFromMJC` now matches MJC clusterOI nodes to the site network by `ehars_uid` and stores the site network's ids for matched people. Returns `{ result, summary }` where `summary = { requested, added, not_found, nodes_added, missing_ehars }`, and logs the counts.
- `app/routes/priority_set.js` — updated route JSDoc to reflect the matching and the summary response.

Frontend (hivtrace-viz):
- `src/hiv_tx_network.js` — `priority_groups_add_from_mjc` reads `summary` from the response and shows "X of Y people added (Z nodes); N not found in your jurisdiction's network." Flags the empty-ClusterOI case (0 added). Backward-compatible: falls back to the old success alert if no `summary` is present.

## Expected behavior

Losing cross-jurisdiction people is expected and correct — a site ClusterOI can only contain people in that site's own network. A high `not_found` for people the site expects to own is now a visible signal of a stale/partial network rather than a silent drop.
