### PR TITLE
fix(mjc): correct sample_dt aggregation in redacted view and unify redaction sentinel checks

### DIFF
--- a/src/clusternetwork.js
+++ b/src/clusternetwork.js
@@ -2365,7 +2365,7 @@ var hivtrace_cluster_network_graph = function (
         );
         if ($redacted_toggle.data("redacted-hidden")) {
           cluster_nodes = cluster_nodes.filter(
-            (n) => !self.entity_id(n).startsWith("REDACTED_")
+            (n) => !self.isRedacted(self.entity_id(n))
           );
         }
       }
@@ -2658,7 +2658,7 @@ var hivtrace_cluster_network_graph = function (
             ),
             (n) => {
               const eid = self.entity_id(n);
-              if (eid.includes("REDACTED")) {
+              if (self.isRedacted(eid)) {
                 return;
               }
               const overlap =

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -1901,6 +1901,7 @@ class HIVTxNetwork {
                 national_priority: g.meets_priority_def,
                 cluster_current_size: entities.length,
                 cluster_dx_recent12_mo: g.cluster_dx_recent12_mo,
+                cluster_dx_recent36_mo: g.cluster_dx_recent36_mo,
                 ...(this.isMJCNetwork
                   ? {}
                   : { cluster_overlap: (g.overlap || {}).sets }),

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -1859,11 +1859,28 @@ class HIVTxNetwork {
                 person_ident_dt: timeDateUtil.hivtrace_date_or_na_if_missing(
                   entity_to_pg_records[eid][0].added
                 ),
-                sample_dt: d3.min(entity_to_g_records[eid], (g) =>
-                  timeDateUtil.hivtrace_date_or_na_if_missing(
-                    this.attribute_node_value_by_id(g, "sample_dt")
-                  )
-                ),
+                // Earliest sample date across the entity's records. Take the min
+                // over parsed Dates (not formatted strings, which sort wrongly),
+                // and surface "REDACTED" rather than a bogus "N/A" when masked.
+                sample_dt: (() => {
+                  const raw = (entity_to_g_records[eid] || []).map((g) =>
+                    this.attribute_node_value_by_id(g, "sample_dt", false, false, true)
+                  );
+                  const dates = [];
+                  for (const v of raw) {
+                    try {
+                      dates.push(this.parse_dates(v));
+                    } catch {
+                      /* "REDACTED" / missing / unparseable */
+                    }
+                  }
+                  if (dates.length) {
+                    return timeDateUtil.hivtrace_date_or_na_if_missing(
+                      d3.min(dates)
+                    );
+                  }
+                  return raw.some((v) => this.isRedacted(v)) ? "REDACTED" : "N/A";
+                })(),
                 new_linked_case: this.priority_groups_is_new_node(
                   entity_to_pg_records[eid][0]
                 )
@@ -4365,11 +4382,14 @@ class HIVTxNetwork {
     return this.primary_key(node);
   }
 
+  // Canonical redaction-sentinel test. The backend emits two shapes: bare
+  // "REDACTED" for scalar values and "REDACTED_<hmac>" for identifiers.
+  isRedacted(v) {
+    return typeof v === "string" && (v === "REDACTED" || v.startsWith("REDACTED_"));
+  }
+
   cleanRedacted(id) {
-    if (typeof id === "string" && id.startsWith("REDACTED_")) {
-      return "REDACTED";
-    }
-    return id;
+    return this.isRedacted(id) ? "REDACTED" : id;
   }
 
   /**


### PR DESCRIPTION
## Summary
Viz-side companion to the backend MJC redaction fixes.

1. sample_dt aggregation (hiv_tx_network.js, individual-records export). The
   "earliest sample date" was computed via d3.min over already-formatted
   MM/DD/YYYY strings, which sorts lexicographically (e.g. picks 01/05/2025 over
   12/31/2009). It also didn't pass check_redacted, so a redacted value fell
   through to DateViewFormatExport("REDACTED") -> threw -> "N/A". It now parses to
   Dates, takes d3.min over Dates then formats once, and surfaces "REDACTED"
   instead of a bogus "N/A". (Pairs with the backend allowlist fix that actually
   delivers sample_dt to owners / "REDACTED" to others.)

2. Redaction sentinel inconsistency. Detection was scattered across
   === "REDACTED", .startsWith("REDACTED_"), and .includes("REDACTED"), which
   disagree on the two backend sentinel shapes (bare "REDACTED" and
   "REDACTED_<hmac>"). Added a canonical HIVTxNetwork.isRedacted(v), routed
   cleanRedacted through it, and replaced the divergent id-checks in
   clusternetwork.js (hide-redacted toggle, overlap modal) with it.

## Cross-repo
Requires the backend allowlist change to deliver sample_dt:
- hivtrace-secure daniel-ji/mjc-redaction-6-16-fixes.
- hivtrace-secure-server daniel-ji/mjc-redaction-6-16-fixes.
