### PR TITLE
feat: hide_gender_fields also hides birth_sex (legacy sex/gender fields)

### DIFF
--- a/src/clusternetwork.js
+++ b/src/clusternetwork.js
@@ -118,24 +118,20 @@ var hivtrace_cluster_network_graph = function (
   self.uniqs = _.mapObject(self.uniqValues, (d) => d.length);
 
   self.schema = self.json[kGlobals.network.GraphAttrbuteID];
-  
-  self._hide_gender_fields = network.check_network_option(
-    options,
-    "hide_gender_fields",
-    false
-  ) || network.check_network_option(
-    options,
-    "no_gender",
-    false
-  ) || network.check_network_option(
-    options,
-    "hide-gender",
-    false
-  );
+
+  self._hide_gender_fields =
+    network.check_network_option(options, "hide_gender_fields", false) ||
+    network.check_network_option(options, "no_gender", false) ||
+    network.check_network_option(options, "hide-gender", false);
 
   if (self._hide_gender_fields && self.schema) {
     _.each(self.schema, (d, k) => {
-      if (k.toLowerCase().includes("gender")) {
+      // Hide the legacy sex/gender fields (gender_identity + birth_sex), but
+      // NOT the new eHARS 4.17 "sex" column or "sex_trans".
+      if (
+        k.toLowerCase().includes("gender") ||
+        k.toLowerCase() === "birth_sex"
+      ) {
         d["_hidden_"] = true;
       }
     });

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -2452,7 +2452,11 @@ class HIVTxNetwork {
 
   inject_attribute_description(key, d) {
     if (kGlobals.network.GraphAttrbuteID in this.json) {
-      if (this._hide_gender_fields && key.toLowerCase().includes("gender")) {
+      if (
+        this._hide_gender_fields &&
+        (key.toLowerCase().includes("gender") ||
+          key.toLowerCase() === "birth_sex")
+      ) {
         d["_hidden_"] = true;
       }
       var new_attr = {};


### PR DESCRIPTION
Extends the opt-in `hide_gender_fields` option (added in #224/#225) so that, when enabled, it hides **both** legacy fields — `gender_identity` **and** `birth_sex` ("Sex Assigned at Birth") — in favor of the eHARS 4.17 `sex` column.

## Why
Previously the option matched schema keys containing the substring `"gender"`, so it only hid `gender_identity`; `birth_sex` stayed visible. Broadening the match to `"sex"` would have wrongly hidden the **new** `sex` column and `sex_trans`, so this targets `birth_sex` explicitly instead.

## Change
`src/clusternetwork.js` and `src/hiv_tx_network.js`:
```js
if (k.toLowerCase().includes("gender") || k.toLowerCase() === "birth_sex") { d["_hidden_"] = true; }
```
- Hides: `gender_identity`, `birth_sex`
- Leaves visible: `sex`, `sex_trans`
- Still **opt-in** (default `false`) — no behavior change unless the consumer sets `hide_gender_fields` / `no_gender` / `hide-gender`.

## Notes
- Targets `release/1.2` so it rides into the (not-yet-tagged) **v1.2.11** alongside the sex preset (#225).
- @spond — this extends your `hide_gender_fields` option to also cover `birth_sex`; flagging since the name still says "gender."
- Consumer side: the app enables this via `display_options` (companion change on the hivtrace-secure side).