### PR TITLE
release(1.2.12): person-based clusterOI growth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hivtrace-viz",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Visualization for the popular HIV-TRACE package",
   "engines": {
     "node": ">=18 || >20"


### PR DESCRIPTION
Bumps `release/1.2` to 1.2.12 for the v1.2.12 release.

Contents since v1.2.11: #233 — clusterOI "Grew" tag and expansion counts are now person-based rather than node-based (veg/hivtrace-secure#550), plus a prettier pass on the two lines it touched.

Verified locally, since neither CI workflow triggers on `release/1.2` PRs: webpack builds clean (default + `es` locale), prettier clean on both changed files.