### PR TITLE
Person-based clusterOI growth on 1.3 (1.3.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hivtrace-viz",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Visualization for the popular HIV-TRACE package",
   "engines": {
     "node": ">=18 || >20"

--- a/src/clustersOfInterest.js
+++ b/src/clustersOfInterest.js
@@ -1396,7 +1396,11 @@ function draw_priority_set_table(self, container, priority_groups) {
             pg.description +
             (pg.pending ? " (new, pending confirmation)" : "") +
             (pg.expanded
-              ? " (" + pg.expanded + " new nodes; pending confirmation)"
+              ? " (" +
+                pg.expanded +
+                " new " +
+                (pg.expanded === 1 ? "person" : "persons") +
+                "; pending confirmation)"
               : ""),
           volatile: true,
           format: (value) =>

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -784,7 +784,8 @@ class HIVTxNetwork {
 
   /** filter the list of CoI to return those which have been automatically expanded */
   priority_groups_expanded() {
-    return _.filter(this.defined_priority_groups, (pg) => pg.autoexpanded).length;
+    return _.filter(this.defined_priority_groups, (pg) => pg.autoexpanded)
+      .length;
   }
 
   /** filter the list of CoI to return those which have been created by the system */
@@ -2071,7 +2072,8 @@ class HIVTxNetwork {
                 added_node_objects.push(n);
               });
 
-              const added_entities = this.unique_entity_list(added_node_objects);
+              const added_entities =
+                this.unique_entity_list(added_node_objects);
               const new_entities = _.filter(
                 added_entities,
                 (e) => !existing_entities.has(e)

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -784,7 +784,7 @@ class HIVTxNetwork {
 
   /** filter the list of CoI to return those which have been automatically expanded */
   priority_groups_expanded() {
-    return _.filter(this.defined_priority_groups, (pg) => pg.expanded).length;
+    return _.filter(this.defined_priority_groups, (pg) => pg.autoexpanded).length;
   }
 
   /** filter the list of CoI to return those which have been created by the system */
@@ -2055,6 +2055,10 @@ class HIVTxNetwork {
             );
 
             if (added_nodes.size) {
+              const existing_entities = new Set(
+                this.unique_entity_list(pg.node_objects)
+              );
+              const added_node_objects = [];
               _.each([...added_nodes], (nid) => {
                 const n = this.json.Nodes[nid];
                 pg.nodes.push({
@@ -2064,12 +2068,23 @@ class HIVTxNetwork {
                   autoadded: true,
                 });
                 pg.node_objects.push(n);
+                added_node_objects.push(n);
               });
+
+              const added_entities = this.unique_entity_list(added_node_objects);
+              const new_entities = _.filter(
+                added_entities,
+                (e) => !existing_entities.has(e)
+              );
+
               pg.validated = false;
-              pg.autoexpanded = true;
               pg.pending = true;
-              pg.expanded = added_nodes.size;
               pg.modified = this.get_reference_date();
+
+              if (new_entities.length > 0) {
+                pg.autoexpanded = true;
+                pg.expanded = new_entities.length;
+              }
             }
           }
 


### PR DESCRIPTION
Forward-ports the person-based clusterOI growth change from v1.2.12 (#233) onto the 1.3 line, and bumps to 1.3.2 so it can be published from here.

Cherry-picked `522b794` + `9424980` — both applied cleanly, no conflicts. The resulting diff matches 1.2.12's substantively: `pg.expanded` counts distinct entities via `unique_entity_list` instead of raw nodes, `priority_groups_expanded()` filters on `autoexpanded`, and the label reads "N new person/persons". Implements veg/hivtrace-secure#550.

Both entity helpers already exist on `release/1.3` with the same signatures, and dependencies are identical between the two lines.

Verified locally, since neither CI workflow triggers on `release/1.3` PRs (`nodejs.yml` and `playwright.yml` are scoped to `master`): webpack builds clean (default + `es`), prettier clean on both changed files. Playwright not run.

Drop the last commit if you'd rather bump the version separately.

Note for publishing: `latest` on npm is currently 1.3.1, so a plain `npm publish` from here moves `latest` to 1.3.2 — which is probably what you want, unlike the 1.2.x line where it needed `--tag legacy-1.2`.
