### PR TITLE
Forward-port: person-based growth fix to release-candidate (#233)

### DIFF
--- a/src/clustersOfInterest.js
+++ b/src/clustersOfInterest.js
@@ -1696,7 +1696,11 @@ function draw_priority_set_table(
             pg.description +
             (pg.pending ? " (new, pending confirmation)" : "") +
             (pg.expanded
-              ? " (" + pg.expanded + " new nodes; pending confirmation)"
+              ? " (" +
+                pg.expanded +
+                " new " +
+                (pg.expanded === 1 ? "person" : "persons") +
+                "; pending confirmation)"
               : ""),
           volatile: true,
           format: (value) =>

--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -1069,7 +1069,7 @@ class HIVTxNetwork {
 
   /** filter the list of CoI to return those which have been automatically expanded */
   priority_groups_expanded() {
-    return _.filter(this.defined_priority_groups, (pg) => pg.expanded).length;
+    return _.filter(this.defined_priority_groups, (pg) => pg.autoexpanded).length;
   }
 
   /** filter the list of CoI to return those which have been created by the system */
@@ -2660,6 +2660,10 @@ class HIVTxNetwork {
             );
 
             if (added_nodes.size) {
+              const existing_entities = new Set(
+                this.unique_entity_list(pg.node_objects)
+              );
+              const added_node_objects = [];
               _.each([...added_nodes], (nid) => {
                 const n = this.json.Nodes[nid];
                 pg.nodes.push({
@@ -2669,12 +2673,23 @@ class HIVTxNetwork {
                   autoadded: true,
                 });
                 pg.node_objects.push(n);
+                added_node_objects.push(n);
               });
+
+              const added_entities = this.unique_entity_list(added_node_objects);
+              const new_entities = _.filter(
+                added_entities,
+                (e) => !existing_entities.has(e)
+              );
+
               pg.validated = false;
-              pg.autoexpanded = true;
               pg.pending = true;
-              pg.expanded = added_nodes.size;
               pg.modified = this.get_reference_date();
+
+              if (new_entities.length > 0) {
+                pg.autoexpanded = true;
+                pg.expanded = new_entities.length;
+              }
             }
           }
 


### PR DESCRIPTION
Forward-ports the person-based growth fix (#233, released in v1.2.12 and v1.3.2) to `release-candidate` (1.4.x / MJC line), which was left without it.

Cherry-picked `d01e1de3` from `release/1.3`, **applied cleanly with no conflicts**. Sergei's authorship preserved.

### What it changes

- `pg.autoexpanded` / `pg.expanded` are set **only when the added nodes introduce new persons**, not merely new sequences. Previously both were set unconditionally on any node addition.
- `priority_groups_expanded()` now filters on `pg.autoexpanded` rather than `pg.expanded`.
- The CoI table label pluralizes on persons ("1 new person" / "N new persons") instead of reporting node counts.

This is the fix for the MA cluster case where `MA_202507_271.1` showed a `Grew` tag after two sequences joined that both belonged to persons already in the cluster, leaving the unique person count unchanged at 23. Per Joel's 7/28 ruling: remove `Grew` if no new people were added.

### Verification

- `unique_entity_list` (the method the fix depends on) is present on `release-candidate` at `src/hiv_tx_network.js:369`, so the cherry-pick is not relying on anything absent from this line.
- Confirmed the old unconditional `pg.expanded = added_nodes.size` is gone and the `new_entities.length > 0` guard is in place.
- `node --check` clean on both modified files.
- `eslint` reports 0 errors on both files; the 17 remaining warnings are pre-existing (`no-console`, `no-unused-vars`) and none fall on changed lines.

### Not included

Only the growth fix is carried over. The rest of the `v1.3.2` delta is dependabot bumps, a Doxygen PDF refresh, a prettier pass, and the version bump, none of which should ride into the RC line. The eHARS 4.17 sex support from that range was already forward-ported separately in #230.
