### PR TITLE
fix(coi): resolve CoI members by person key when a sequence ID changes

### DIFF
--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -1680,8 +1680,9 @@ class HIVTxNetwork {
                         the sequences belong
                     (3) they will be handled in the next step
               */
-              if (this.has_multiple_sequences) {
-                let entities = this.primary_key_list[nodeid];
+              if (this.primary_key_list) {
+                let entities =
+                  this.primary_key_list[this.entity_id_from_string(nodeid)];
                 if (entities) {
                   if (entities.length == 1) {
                     node.name = entities[0].id;
@@ -2057,7 +2058,7 @@ class HIVTxNetwork {
 
             if (added_nodes.size) {
               const existing_entities = new Set(
-                this.unique_entity_list(pg.node_objects)
+                this.unique_entity_list_from_ids(_.map(pg.nodes, (n) => n.name))
               );
               const added_node_objects = [];
               _.each([...added_nodes], (nid) => {


### PR DESCRIPTION
Follow-up to #236 / veg/hivtrace-secure#550. QC reports that changing a sequence produces no growth (correct), but changing a **sequence ID** still trips the `Grew` tag (incorrect) — the person is unchanged.

## Cause

CoI membership is stored as full node IDs of the form `eHARS_uid|sequenceID`. When a person's sequence ID changes between builds, `A|S1` becomes `A|S2` and the viz loses the person, then re-discovers them as a stranger:

1. **Resolution fails.** The stored name is not in `node_id_to_object`, so we fall through to `primary_key_list[nodeid]`. `primary_key_list` is keyed by *primary key* (`A`), so indexing it with the full string `A|S1` misses. That fallback was only ever written for the SSPP→MSPP migration, where the CoI held a bare `A`. The person lands in `pg.not_in_network` and is absent from `pg.node_objects`.
2. **Auto-expansion re-adds the node.** `core_node_set` maps `pg.nodes` names through `nodeID2idx`, so `A|S1` yields `undefined` and `A|S2` is not in the core set. The traversal reaches it through its cluster neighbors and adds it.
3. **Growth counts them as new.** `existing_entities` was computed from `pg.node_objects`, which per step 1 no longer contains `A`, so `new_entities` is `["A"]` and `autoexpanded` is set.

This reproduces the original #550 symptom exactly — `Grew` with no matching `+N new` in the size column. That column groups `pg.nodes` by entity and only counts an entity as new when *all* its records are `autoadded`; person `A` now has both the stale `A|S1` record and the fresh autoadded `A|S2`, so it is excluded. The two counters disagreed because one read `pg.node_objects` and the other read `pg.nodes`.

## Change

Three lines in `src/hiv_tx_network.js`:

- Look the vanished node up by its entity ID (`primary_key_list[this.entity_id_from_string(nodeid)]`). This is strictly more general — a legacy bare `A` still has primary key `A`, so the SSPP→MSPP migration is unaffected. The existing single-sequence branch rewrites `node.name` in place and preserves `added`/`kind`, so the member keeps their original enrollment date instead of being re-stamped as autoadded. Multi-sequence persons route into the existing `mspp_ms_nodes` path, which also preserves `added`.
- Relax the `has_multiple_sequences` guard to `primary_key_list`. That flag is only true once some person actually has 2+ sequences, so on a network whose IDs carry a person component but where every person has exactly one sequence the fallback was dead code. No false positives: we only reach this branch when the ID is absent from `node_id_to_object`, so a pipe-less ID can only match if some node is `nodeid|something`, which is precisely the intended legacy case.
- Baseline growth on `pg.nodes` rather than `pg.node_objects`. `pg.nodes` is fully injected and pruned earlier in the same loop iteration and deliberately retains persons missing from the current network, so a person the CoI already knows about can never be counted as growth regardless of whether identity resolution succeeded. This also makes the `Grew` tag and the size column's `new` count derive from the same source.

With the name re-resolved, `core_node_set` resolves, auto-expansion never proposes the node, and the `Grew` tag, the `N removed` badge, and the export's `person_ident_dt` all correct themselves as a consequence.

## Verification

`npx prettier --check` clean; `npx eslint` reports 0 errors (10 pre-existing `no-console`/`no-unused-vars` warnings elsewhere in the file, unchanged); `npm run build` compiles successfully.

Not yet covered by an automated test — the modules are ESM/webpack-only and the repo has no unit-test harness, so this was traced through the source rather than executed. Suggest QC re-run the sequence-ID-change fixture, plus three regressions: a legacy bare-eHARS CoI still migrates, a genuine new person still sets `Grew` with a matching `+N new`, and a person truly dropped from the network still lands in `not_in_network`.

## Note for QC

`autoexpanded` is persisted through `priority_groups_export` and nothing in the viz clears it — re-saving through the editor carries the old value forward while resetting `pending`. If clearing is not handled in hivtrace-secure, CoIs already mislabeled in prod will keep the `Grew` badge after this ships.