### PR TITLE
Forward-port: resolve CoI members by person key when a sequence ID changes (#238)

### DIFF
--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -2283,8 +2283,9 @@ class HIVTxNetwork {
                         the sequences belong
                     (3) they will be handled in the next step
               */
-              if (this.has_multiple_sequences) {
-                let entities = this.primary_key_list[nodeid];
+              if (this.primary_key_list) {
+                let entities =
+                  this.primary_key_list[this.entity_id_from_string(nodeid)];
                 if (entities) {
                   if (entities.length == 1) {
                     node.name = entities[0].id;
@@ -2661,7 +2662,7 @@ class HIVTxNetwork {
 
             if (added_nodes.size) {
               const existing_entities = new Set(
-                this.unique_entity_list(pg.node_objects)
+                this.unique_entity_list_from_ids(_.map(pg.nodes, (n) => n.name))
               );
               const added_node_objects = [];
               _.each([...added_nodes], (nid) => {


### PR DESCRIPTION
Forward-ports `475cd06d` (#238) from `release/1.3` to `release-candidate` (the 1.4 line). Cherry-picked cleanly, no conflicts.

## Why this follows #237

#237 forward-ported the person-based CoI growth fix (#233/#236). #238 landed on `release/1.3` six days later and fixes a bug in exactly that area, so carrying #237 across without this one reintroduces the problem on 1.4.

A CoI stores membership as full node IDs (`eHARS_uid|sequenceID`). When a person's sequence ID changed between network builds, the stored ID no longer resolved — the fallback indexed `primary_key_list` (keyed by primary key) with the full node ID, so it only matched legacy CoI records holding a bare eHARS ID. The person fell through to `not_in_network`, auto-expansion re-discovered their new node and counted it as a **new person**, setting the Grew tag without a matching "new" count in the size column.

## The change

```js
- if (this.has_multiple_sequences) {
-   let entities = this.primary_key_list[nodeid];
+ if (this.primary_key_list) {
+   let entities =
+     this.primary_key_list[this.entity_id_from_string(nodeid)];
```

Looks the node up by entity ID so an existing member is re-resolved to their current sequence in place, preserving the original added date. The guard is relaxed to cover networks whose IDs carry a person component even when no person happens to have multiple sequences.

Second hunk baselines growth on the CoI's recorded membership rather than the network-resolved node objects, so a person the CoI already knows about is never counted as growth, and the Grew tag and the size column's "new" count derive from the same source.

## Verification

`node --check` passes. Both hunks confirmed present; `unique_entity_list_from_ids` already existed on `release-candidate`. Diff is +4/-3 in one file, identical to what landed on 1.3.

Not runtime-tested — worth exercising a CoI whose member sequence ID changes between builds.

## Remaining 1.3 → 1.4 gap after this

Three Dependabot bumps (`follow-redirects`, `@babel/plugin-transform-modules-systemjs`, `shell-quote`) are still only on `release/1.3`. The eHARS 4.17 Sex work is already on `release-candidate` via #230.
