### PR TITLE
fix(coi): narrow member re-resolution and guard schema-less attributes

### DIFF
--- a/src/hiv_tx_network.js
+++ b/src/hiv_tx_network.js
@@ -1681,9 +1681,9 @@ class HIVTxNetwork {
                     (3) they will be handled in the next step
               */
               if (this.primary_key_list) {
-                let entities =
-                  this.primary_key_list[this.entity_id_from_string(nodeid)];
-                if (entities) {
+                const eid = this.entity_id_from_string(nodeid);
+                let entities = this.primary_key_list[eid];
+                if (entities && (entities.length == 1 || nodeid === eid)) {
                   if (entities.length == 1) {
                     node.name = entities[0].id;
                     pg.node_objects.push(entities[0]);
@@ -3310,7 +3310,7 @@ class HIVTxNetwork {
               if (_.size(unique_values) == 1) {
                 return [k, values[0][kGlobals.network.NodeAttributeID][k]];
               } else {
-                if (proto.type == "Date") {
+                if (proto && proto.type == "Date") {
                   try {
                     return [
                       k,


### PR DESCRIPTION
Prepares v1.3.4. Two hunks in `src/hiv_tx_network.js`, **4 lines changed, net zero**.

## What v1.3.3 actually did

`primary_key_list` is keyed by *primary key* (`:183-193`), so v1.3.2's literal `primary_key_list[nodeid]` could only ever hit when the stored member name was a bare eHARS ID. Switching the key to `entity_id_from_string(nodeid)` did not narrow a guard — **it activated code that had never run**. A stale *full* sequence ID (`A|S9`) now resolved to person `A`'s entire current sequence list. When that person has 2+ sequences, control reached the MSPP migration branch (`:1694-1712`) and the injection loop (`:1750-1757`) pushed **every one of their sequences** into `pg.node_objects` and `pg.nodes`.

## Correction to the earlier diagnosis

The `proto.type` crash is **not** exclusive to v1.3.3, and the "every tab empty" symptom probably is not v1.3.3's doing:

- A CoI storing a **bare** eHARS ID for a person with 2+ sequences reaches the identical throw in **v1.3.2** (simulation case 3 throws under all three versions).
- The same crash line is reachable **synchronously over the whole network** from `src/clusternetwork.js:6155-6157` via `define_node_search_table` (`:8694`) — a path byte-identical in v1.3.2. That synchronous route is the only one that can blank every tab, since `HandleAppError` (`html/priority-sets-args.html:936-946`) fires only from the synchronous catch at `:1068-1073`; `draw_priority_set_table` is reached asynchronously.

So **hunk 2 is the load-bearing crash fix**. Hunk 1 fixes a real but distinct v1.3.3 regression: silently expanding CoI membership and writing it back to the server.

**Outstanding discriminating datum:** the *first* un-elided console error on training. If its top frame names `define_node_search_table` / `clusternetwork.js:6156` rather than `draw_priority_set_table`, v1.3.3 is exonerated for the outage. This does not change the patch, only the release note.

## The patch

**Hunk 1** (`:1683-1686`) — hoist the entity ID and narrow the gate to `entities && (entities.length == 1 || nodeid === eid)`. `nodeid === eid` is true exactly when the stored name is a bare eHARS ID, i.e. precisely what v1.3.2 admitted. The gate now accepts {everything v1.3.2 accepted} ∪ {single-candidate re-resolution of a stale sequence ID}. A multi-candidate stale ID falls through to `not_in_network` at `:1715`, as in v1.3.2. Dropping v1.3.2's outer `has_multiple_sequences` guard cannot widen the MSPP branch, since `entities.length > 1` implies `has_multiple_sequences` by construction at `:186-193`.

**Hunk 2** (`:3313`) — `if (proto && proto.type == "Date")`. A schema-less key falls through to the existing sort-and-join at `:3325-3328`, matching how `attribute_node_value_by_id` already tolerates undeclared keys (`:952-979`).

The v1.3.3 growth baseline at `:2060-2062` is **deliberately untouched** — reverting it reintroduces the original false-`Grew` bug for exactly the case hunk 1 now routes to `not_in_network`.

## Verification

Six-case matrix run against a line-faithful port of the resolution loop and the crash site under v1.3.2 / v1.3.3 / patched:

| case | v1.3.2 | v1.3.3 | patched |
|---|---|---|---|
| stale full ID, 2 seqs | `[B\|S1]`, not_in_network | **THREW** | identical to v1.3.2 |
| stale full ID, 1 seq | not_in_network | resolved | identical to v1.3.3 (seqID fix preserved) |
| legacy bare ID, 2 seqs | **THREW** | **THREW** | **THREW** → OK with hunk 2 |
| bare ID, 1 seq | same | same | same |
| entity absent | same | same | same |

With the guard applied every case reports OK, including the one that throws in unpatched v1.3.2.

`node --check` passes; prettier clean under the repo's own 2.8.0 (note: a bare `npx prettier` resolves v3 and falsely reports the file dirty — use `--no-install`); eslint 0 errors; `npm run build` compiles. This is a simulation of the logic, not the real module — there is still no unit harness — so a smoke test on a real MSPP network is warranted before release.

## Operational notes — not fixed by this patch

1. **Server-side CoI records may already be damaged.** While v1.3.3 was live, `priority_groups_validate` mutated `pg.nodes` in place and `load_priority_sets` re-POSTed every CoI (`:2542` → `:1234-1245`) *before* the throw at `:2546`. `priority_groups_export` serializes `nodes: g.nodes` verbatim with no `not_in_network` filtering (`:1194-1213`). Affected CoIs may now contain injected sibling sequences, duplicated records, and appended migration notes. Inspect and repair the stored JSON.
2. **Sticky `Grew` flags survive this patch.** `pg.autoexpanded = true` (`:2088`) is the only assignment to true and nothing resets it; `clustersOfInterest.js:427` carries the old value forward. Any CoI already flagged stays flagged, which may look like the fix failed.
3. **The structural producer of schema-less attributes is unfixed.** Cluster/subcluster views shallow-clone nodes but deep-copy the schema (`clusternetwork.js:685-691`, `:1209-1214`, `:1228-1234`), so a view-side injection mutates the primary network's nodes while its description lands only in the view's private schema. `subcluster_temporal_view` (`:1153-1161`) does exactly this after a date-slider drag and is the prime suspect for the training network's undeclared key. Worth dumping `_.difference(_.keys(node.patient_attributes), _.keys(json.patient_attribute_schema))` on that data.